### PR TITLE
Expose global handlers for HTML events

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,6 +522,6 @@
         </div>
     </div>
 
-    <script type="module" src="script.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1225,3 +1225,29 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
+
+// Placeholder implementations for future features
+function filterApplications(status) {
+    console.warn('filterApplications is not implemented yet:', status);
+}
+
+function exportDatabaseBackup() {
+    console.warn('exportDatabaseBackup is not implemented yet.');
+}
+
+function importDatabaseBackup() {
+    console.warn('importDatabaseBackup is not implemented yet.');
+}
+
+// Expose functions for inline handlers
+window.showEmployeeLogin = showEmployeeLogin;
+window.showAdminLogin = showAdminLogin;
+window.switchTab = switchTab;
+window.editEmployee = editEmployee;
+window.deleteEmployee = deleteEmployee;
+window.deleteAllEmployees = deleteAllEmployees;
+window.closeErrorModal = closeErrorModal;
+window.closeEditModal = closeEditModal;
+window.filterApplications = filterApplications;
+window.exportDatabaseBackup = exportDatabaseBackup;
+window.importDatabaseBackup = importDatabaseBackup;


### PR DESCRIPTION
## Summary
- Drop `type="module"` from script include to restore classic script loading
- Provide stubbed handlers for application filters and backups
- Expose all HTML-triggered handlers on `window` so inline events can call them

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4d4f65b408325b3308dbf649842c4