### PR TITLE
Hide employee tabs for admins

### DIFF
--- a/script.js
+++ b/script.js
@@ -894,10 +894,18 @@ function showMainApp() {
 
 function configureTabsForUser() {
     const isAdmin = currentUserType === 'admin';
-    
+
     document.getElementById('tabEmployeeManagement').style.display = isAdmin ? 'block' : 'none';
     document.getElementById('tabApplicationStatus').style.display = isAdmin ? 'block' : 'none';
     document.getElementById('tabHolidayDates').style.display = isAdmin ? 'block' : 'none';
+
+    // Toggle visibility for employee-specific tabs based on user role
+    document.getElementById('tabLeaveRequest').style.display = isAdmin ? 'none' : 'block';
+    document.getElementById('tabCheckHistory').style.display = isAdmin ? 'none' : 'block';
+
+    // Also hide the corresponding tab content sections to prevent access
+    document.getElementById('leave-request').style.display = isAdmin ? 'none' : 'block';
+    document.getElementById('check-history').style.display = isAdmin ? 'none' : 'block';
 }
 
 function displayWelcome() {


### PR DESCRIPTION
## Summary
- Toggle visibility of leave-request and check-history tabs based on admin status
- Mirror tab visibility on corresponding content sections to prevent admin access

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4e1ea86008325be00e7e6da30a27e