### PR TITLE
Restrict employee management to admins

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,8 +268,9 @@
         </div>
 
         <!-- Employee Management Tab -->
-        <div id="employee-management" class="tab-content">
-            <div class="admin-panel">
+        <div id="adminSection" style="display:none;">
+            <div id="employee-management" class="tab-content">
+                <div class="admin-panel">
                 <div class="section">
                     <h2>Add New Employee</h2>
                     <form id="employeeForm" class="employee-form">
@@ -326,6 +327,7 @@
                     </div>
                 </div>
             </div>
+        </div>
         </div>
 
         <!-- Application Status Tab -->

--- a/script.js
+++ b/script.js
@@ -898,14 +898,15 @@ function configureTabsForUser() {
     document.getElementById('tabEmployeeManagement').style.display = isAdmin ? 'block' : 'none';
     document.getElementById('tabApplicationStatus').style.display = isAdmin ? 'block' : 'none';
     document.getElementById('tabHolidayDates').style.display = isAdmin ? 'block' : 'none';
+    document.getElementById('adminSection').style.display = isAdmin ? 'block' : 'none';
 
     // Toggle visibility for employee-specific tabs based on user role
     document.getElementById('tabLeaveRequest').style.display = isAdmin ? 'none' : 'block';
-    document.getElementById('tabCheckHistory').style.display = isAdmin ? 'none' : 'block';
+    document.getElementById('tabCheckHistory').style.display = 'none';
 
     // Also hide the corresponding tab content sections to prevent access
     document.getElementById('leave-request').style.display = isAdmin ? 'none' : 'block';
-    document.getElementById('check-history').style.display = isAdmin ? 'none' : 'block';
+    document.getElementById('check-history').style.display = 'none';
 }
 
 function displayWelcome() {


### PR DESCRIPTION
## Summary
- Wrap employee management tab in `#adminSection` to hide it for non-admin users.
- Toggle `#adminSection` display based on login role and hide check-history tab for employees.

## Testing
- `node --check script.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4e6cb08208325b5d7fa373f9f9af8