### PR TITLE
feat: filter leave history by employee

### DIFF
--- a/script.js
+++ b/script.js
@@ -1239,6 +1239,40 @@ async function loadLeaveApplications() {
     }
 }
 
+async function loadLeaveHistory(employeeId) {
+    try {
+        const apps = await room
+            .collection('leave_application')
+            .makeRequest('GET', `?employee_id=${encodeURIComponent(employeeId)}`);
+
+        const tbody = document.getElementById('historyTableBody');
+        tbody.innerHTML = '';
+
+        apps.forEach(app => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${app.application_id || app.id}</td>
+                <td>${app.leave_type}</td>
+                <td>${app.start_date}</td>
+                <td>${app.end_date}</td>
+                <td>${app.total_days}</td>
+                <td>${app.status}</td>
+                <td>${app.date_applied || ''}</td>
+                <td>—</td>
+            `;
+            tbody.appendChild(row);
+        });
+
+        if (apps.length === 0) {
+            const row = document.createElement('tr');
+            row.innerHTML = '<td colspan="8">No leave applications found</td>';
+            tbody.appendChild(row);
+        }
+    } catch (error) {
+        console.error('Error loading leave history:', error);
+    }
+}
+
 async function loadHolidays() {
     try {
         const holidays = await room.collection('holiday').getList();
@@ -1276,6 +1310,11 @@ function switchTab(tabName) {
     const targetButton = document.getElementById(`tab${tabName.charAt(0).toUpperCase() + tabName.slice(1).replace('-', '')}`);
     if (targetButton) {
         targetButton.classList.add('active');
+    }
+
+    // Load leave history when user views the history tab
+    if (tabName === 'check-history' && currentUser) {
+        loadLeaveHistory(currentUser.id);
     }
 }
 

--- a/server.py
+++ b/server.py
@@ -118,7 +118,14 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                     results = [dict(row) for row in cursor.fetchall()]
                     
                 elif collection == 'leave_application':
-                    cursor = conn.execute('SELECT * FROM leave_applications ORDER BY created_at DESC')
+                    # Get leave applications with optional employee filter
+                    if 'employee_id' in query:
+                        cursor = conn.execute(
+                            'SELECT * FROM leave_applications WHERE employee_id = ? ORDER BY created_at DESC',
+                            (query['employee_id'][0],)
+                        )
+                    else:
+                        cursor = conn.execute('SELECT * FROM leave_applications ORDER BY created_at DESC')
                     results = [dict(row) for row in cursor.fetchall()]
                 elif collection == 'holiday':
                     cursor = conn.execute('SELECT * FROM holidays ORDER BY date')


### PR DESCRIPTION
## Summary
- allow `/api/leave_application` to filter by `employee_id`
- load leave history on client for the current employee
- trigger leave history load when switching to the history tab

## Testing
- `python -m py_compile server.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4ee026eb88325bf6c25ff7d218edb