### PR TITLE
Fix employee check history tab visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -935,11 +935,11 @@ function configureTabsForUser() {
 
     // Toggle visibility for employee-specific tabs based on user role
     document.getElementById('tabLeaveRequest').style.display = isAdmin ? 'none' : 'block';
-    document.getElementById('tabCheckHistory').style.display = 'none';
+    document.getElementById('tabCheckHistory').style.display = isAdmin ? 'none' : 'block';
 
     // Also hide the corresponding tab content sections to prevent access
-    document.getElementById('leave-request').style.display = isAdmin ? 'none' : 'block';
-    document.getElementById('check-history').style.display = 'none';
+    document.getElementById('leave-request').style.display = isAdmin ? 'none' : '';
+    document.getElementById('check-history').style.display = isAdmin ? 'none' : '';
 }
 
 function displayWelcome() {


### PR DESCRIPTION
## Summary
- Show Check History tab for employees while hiding it for admins
- Reset tab content display to allow `.active` class control

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b4edf0cbe883259841028e9a866cd9