### PR TITLE
Map hyphenated tabs to camelCase button ids

### DIFF
--- a/script.js
+++ b/script.js
@@ -1251,10 +1251,19 @@ async function loadHolidays() {
 function switchTab(tabName) {
     /* @tweakable whether to log tab switching for debugging */
     const logTabSwitching = true;
-    
+
     if (logTabSwitching) {
         console.log(`🔄 Switching to tab: ${tabName}`);
     }
+
+    // Map hyphenated tab names to their camel-cased button IDs
+    const tabButtonIds = {
+        'leave-request': 'tabLeaveRequest',
+        'check-history': 'tabCheckHistory',
+        'employee-management': 'tabEmployeeManagement',
+        'application-status': 'tabApplicationStatus',
+        'holiday-dates': 'tabHolidayDates'
+    };
     
     // Hide all tab contents
     document.querySelectorAll('.tab-content').forEach(tab => {
@@ -1273,9 +1282,12 @@ function switchTab(tabName) {
     }
     
     // Activate corresponding tab button
-    const targetButton = document.getElementById(`tab${tabName.charAt(0).toUpperCase() + tabName.slice(1).replace('-', '')}`);
-    if (targetButton) {
-        targetButton.classList.add('active');
+    const targetButtonId = tabButtonIds[tabName];
+    if (targetButtonId) {
+        const targetButton = document.getElementById(targetButtonId);
+        if (targetButton) {
+            targetButton.classList.add('active');
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Map tab names like `check-history` to their camelCase button IDs via a lookup table.
- Ensure tab switching activates the correct button based on mapping.

## Testing
- `node <<'NODE' ...` (switching to `check-history` updates active classes)
- `npm test` (fails: ENOENT could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b4edffa2088325b882e80f31d85ad1