### PR TITLE
Reset login forms and disable autofill

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
             <button id="backToEntryFromEmployee" class="back-btn">← Back</button>
         </div>
         <div class="login-form active">
-            <form id="loginEmployeeForm">
+            <form id="loginEmployeeForm" autocomplete="off">
                 <input type="email" id="loginEmployeeEmail" placeholder="Enter your email address" autocomplete="off" required />
                 <button type="submit" class="btn-login">Login</button>
             </form>
@@ -48,9 +48,9 @@
             <button id="backToEntryFromAdmin" class="back-btn">← Back</button>
         </div>
         <div class="login-form active">
-            <form id="loginAdminForm">
+            <form id="loginAdminForm" autocomplete="off">
                 <input type="text" id="loginAdminUsername" placeholder="Username" autocomplete="off" required />
-                <input type="password" id="loginAdminPassword" placeholder="Password" autocomplete="off" required />
+                <input type="password" id="loginAdminPassword" placeholder="Password" autocomplete="new-password" required />
                 <button type="submit" class="btn-login">Login</button>
             </form>
         </div>

--- a/script.js
+++ b/script.js
@@ -735,11 +735,16 @@ function showEntrySelection() {
 function showEmployeeLogin() {
     /* @tweakable whether to log navigation to employee login */
     const logNavigation = true;
-    
+
     if (logNavigation) {
         console.log('🔄 Navigating to employee login');
     }
-    
+
+    const employeeForm = document.getElementById('loginEmployeeForm');
+    if (employeeForm) {
+        employeeForm.reset();
+    }
+
     document.getElementById('entryContainer').style.display = 'none';
     document.getElementById('employeeLoginContainer').style.display = 'block';
     document.getElementById('adminLoginContainer').style.display = 'none';
@@ -749,11 +754,16 @@ function showEmployeeLogin() {
 function showAdminLogin() {
     /* @tweakable whether to log navigation to admin login */
     const logNavigation = true;
-    
+
     if (logNavigation) {
         console.log('🔄 Navigating to admin login');
     }
-    
+
+    const adminForm = document.getElementById('loginAdminForm');
+    if (adminForm) {
+        adminForm.reset();
+    }
+
     document.getElementById('entryContainer').style.display = 'none';
     document.getElementById('employeeLoginContainer').style.display = 'none';
     document.getElementById('adminLoginContainer').style.display = 'block';


### PR DESCRIPTION
## Summary
- Clear employee and admin login fields whenever their login pages are shown.
- Disable browser autofill for both login forms and prevent password managers from suggesting credentials for the admin password field.

## Testing
- `node --check script.js`
- `npx -y htmlhint index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f8484f888325ba7a5b196864f53f