### PR TITLE
Fix API path parsing to support query parameters

### DIFF
--- a/server.py
+++ b/server.py
@@ -63,15 +63,16 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
     def handle_api_request(self):
         """Handle API requests for database operations"""
         try:
-            path_parts = self.path.split('/')
+            parsed = urllib.parse.urlparse(self.path)
+            path_parts = parsed.path.split('/')
             if len(path_parts) < 3:
                 self.send_error(400, "Invalid API path")
                 return
-            
+
             collection = path_parts[2]
-            
+
             if self.command == 'GET':
-                self.handle_get_request(collection, path_parts)
+                self.handle_get_request(collection, path_parts, parsed.query)
             elif self.command == 'POST':
                 self.handle_post_request(collection)
             elif self.command == 'PUT':
@@ -85,13 +86,12 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
             print(f"❌ API request error: {e}")
             self.send_error(500, f"Internal Server Error: {str(e)}")
     
-    def handle_get_request(self, collection, path_parts):
+    def handle_get_request(self, collection, path_parts, query_string):
         """Handle GET requests"""
         with db_lock:
             conn = get_db_connection()
             try:
-                parsed = urllib.parse.urlparse(self.path)
-                query = urllib.parse.parse_qs(parsed.query)
+                query = urllib.parse.parse_qs(query_string)
                 
                 # @tweakable handle config endpoint for admin email retrieval
                 if collection == 'config' and len(path_parts) > 3:


### PR DESCRIPTION
## Summary
- Parse API requests with `urllib.parse.urlparse` to avoid including query strings in path parts
- Pass parsed query string to GET handler for consistent query parameter handling

## Testing
- `python -m py_compile server.py`
- `curl -s http://localhost:8000/api/leave_application?employee_id=76918caf-6fde-4707-a765-b1074022fcc0`

------
https://chatgpt.com/codex/tasks/task_e_68b5019fb4fc83258114609c8b29bcfd