### PR TITLE
refactor: use collection update for application status

### DIFF
--- a/script.js
+++ b/script.js
@@ -1323,16 +1323,7 @@ async function loadLeaveApplications() {
 
 async function updateApplicationStatus(id, newStatus) {
     try {
-        const response = await fetch(`/api/leave_application/${encodeURIComponent(id)}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ status: newStatus })
-        });
-
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-        }
-
+        await room.collection('leave_application').update(id, { status: newStatus });
         await loadLeaveApplications();
     } catch (error) {
         console.error('Error updating application status:', error);


### PR DESCRIPTION
## Summary
- replace fetch call in updateApplicationStatus with room.collection update
- rely on collection's built-in error handling and reload application table

## Testing
- `python3 -m py_compile server.py`
- `node --check script.js` *(fails: Unexpected end of input in script.js:1513)*

------
https://chatgpt.com/codex/tasks/task_e_68b50f18fe248325bf8fb91f0bf82156