### PR TITLE
Initialize entry buttons with fallback handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@
             <h1>🏢 Employee Leave Management System</h1>
             <p>Please select your login type</p>
             <div class="entry-buttons">
-                <button id="employeeEntryBtn" class="entry-btn employee-btn">
+                <button id="employeeEntryBtn" class="entry-btn employee-btn" onclick="showEmployeeLogin()">
                     👤 Employee Login
                 </button>
-                <button id="adminEntryBtn" class="entry-btn admin-btn">
+                <button id="adminEntryBtn" class="entry-btn admin-btn" onclick="showAdminLogin()">
                     🔐 Administrator Login
                 </button>
             </div>

--- a/script.js
+++ b/script.js
@@ -363,7 +363,9 @@ document.addEventListener('DOMContentLoaded', function() {
         console.log('- DOM Ready State:', document.readyState);
         console.log('- Script Loading Time:', new Date().toISOString());
     }
-    
+
+    initEntryButtons();
+
     // Try to restore authentication state first
     if (AUTO_RESTORE_AUTH && PERSIST_AUTH_STATE) {
         try {
@@ -731,6 +733,25 @@ function showEntrySelection() {
     document.getElementById('adminLoginContainer').style.display = 'none';
     document.getElementById('appContainer').style.display = 'none';
 }
+
+function initEntryButtons() {
+    const employeeBtn = document.getElementById('employeeEntryBtn');
+    const adminBtn = document.getElementById('adminEntryBtn');
+
+    if (employeeBtn) {
+        employeeBtn.addEventListener('click', showEmployeeLogin);
+    } else {
+        console.error('employeeEntryBtn not found');
+    }
+
+    if (adminBtn) {
+        adminBtn.addEventListener('click', showAdminLogin);
+    } else {
+        console.error('adminEntryBtn not found');
+    }
+}
+
+initEntryButtons();
 
 function showEmployeeLogin() {
     /* @tweakable whether to log navigation to employee login */
@@ -1420,6 +1441,8 @@ function switchTab(tabName) {
     if (tabName === 'check-history' && currentUser) {
         loadLeaveHistory(currentUser.id);
     }
+}
+
 // Utility functions
 async function editEmployee(employeeId) {
     console.log(`Editing employee: ${employeeId}`);


### PR DESCRIPTION
## Summary
- add `initEntryButtons` to wire up entry login buttons and log missing elements
- invoke `initEntryButtons` both on definition and during `DOMContentLoaded`
- add inline `onclick` fallbacks for entry buttons

## Testing
- `node --check script.js`
- `npm test` (fails: missing `package.json`)


------
https://chatgpt.com/codex/tasks/task_e_68b5155f441c83259200cb765716230c