### PR TITLE
Clean up leave status tables and style action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,8 +255,6 @@
                                 <th>End Date</th>
                                 <th>Total Days</th>
                                 <th>Status</th>
-                                <th>Date Applied</th>
-                                <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody id="historyTableBody">
@@ -372,7 +370,6 @@
                                     <th>End Date</th>
                                     <th>Total Days</th>
                                     <th>Status</th>
-                                    <th>Date Applied</th>
                                     <th>Actions</th>
                                 </tr>
                             </thead>

--- a/script.js
+++ b/script.js
@@ -1310,8 +1310,7 @@ async function loadLeaveApplications() {
                 <td>${app.end_date}</td>
                 <td>${app.total_days}</td>
                 <td>${app.status}</td>
-                <td>${app.date_applied || ''}</td>
-                <td>
+                <td class="application-actions">
                     <button class="approve-btn">Approve</button>
                     <button class="reject-btn">Reject</button>
                 </td>
@@ -1334,7 +1333,7 @@ async function loadLeaveApplications() {
 
         if (applications.length === 0) {
             const row = document.createElement('tr');
-            row.innerHTML = '<td colspan="9">No leave applications found</td>';
+            row.innerHTML = '<td colspan="8">No leave applications found</td>';
             tbody.appendChild(row);
         }
     } catch (error) {
@@ -1370,15 +1369,13 @@ async function loadLeaveHistory(employeeId) {
                 <td>${app.end_date}</td>
                 <td>${app.total_days}</td>
                 <td>${app.status}</td>
-                <td>${app.date_applied || ''}</td>
-                <td>—</td>
             `;
             tbody.appendChild(row);
         });
 
         if (apps.length === 0) {
             const row = document.createElement('tr');
-            row.innerHTML = '<td colspan="8">No leave applications found</td>';
+            row.innerHTML = '<td colspan="6">No leave applications found</td>';
             tbody.appendChild(row);
         }
     } catch (error) {

--- a/styles.css
+++ b/styles.css
@@ -595,6 +595,20 @@ tr:hover {
     border-radius: 4px;
 }
 
+.approve-btn {
+    background: var(--success-color);
+    color: #fff;
+    border: 2px solid var(--success-color);
+    cursor: pointer;
+}
+
+.reject-btn {
+    background: var(--error-color);
+    color: #fff;
+    border: 2px solid var(--error-color);
+    cursor: pointer;
+}
+
 /* Notification Styles */
 .notifications-section {
     margin-bottom: 30px;


### PR DESCRIPTION
## Summary
- Remove Date Applied and Actions columns from history table
- Drop Date Applied from admin application view
- Add green/red styling for Approve and Reject buttons

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b518c6001483258f21d8946c1b9ba4