### PR TITLE
Add loading overlay and button state handling for status updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -1344,13 +1344,23 @@ async function loadLeaveApplications() {
 }
 
 async function updateApplicationStatus(id, newStatus) {
+    showLoading();
+
+    // Disable all action buttons to prevent duplicate requests
+    const actionButtons = document.querySelectorAll('.approve-btn, .reject-btn');
+    actionButtons.forEach(btn => (btn.disabled = true));
+
     try {
         await room.collection('leave_application').update(id, { status: newStatus });
         await loadLeaveApplications();
         await loadApprovedLeaves();
+        alert('Application status updated successfully');
     } catch (error) {
         console.error('Error updating application status:', error);
-        alert('Failed to update application status');
+        alert(`Failed to update application status: ${error.message}`);
+    } finally {
+        actionButtons.forEach(btn => (btn.disabled = false));
+        hideLoading();
     }
 }
 


### PR DESCRIPTION
## Summary
- Show loading overlay and disable action buttons when updating a leave application
- Re-enable buttons and hide overlay after update using a `finally` block
- Provide success and detailed error alerts for application status updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b52831befc8325a1aa92c67bcd705d