### PR TITLE
Fix leave application status update identifier

### DIFF
--- a/script.js
+++ b/script.js
@@ -1320,13 +1320,13 @@ async function loadLeaveApplications() {
             const approveBtn = row.querySelector('.approve-btn');
             if (approveBtn) {
                 approveBtn.addEventListener('click', () =>
-                    updateApplicationStatus(app.id, 'Approved')
+                    updateApplicationStatus(app.id ?? app.application_id, 'Approved')
                 );
             }
             const rejectBtn = row.querySelector('.reject-btn');
             if (rejectBtn) {
                 rejectBtn.addEventListener('click', () =>
-                    updateApplicationStatus(app.id, 'Rejected')
+                    updateApplicationStatus(app.id ?? app.application_id, 'Rejected')
                 );
             }
         });


### PR DESCRIPTION
## Summary
- use `app.id ?? app.application_id` when updating leave application status so the server can find the record

## Testing
- `curl -i -X PUT http://localhost:8090/api/leave_application/APP-1 -H 'Content-Type: application/json' -d '{"status":"Approved"}'`
- `curl -s -i -X PUT http://localhost:8090/api/leave_application/app1 -H 'Content-Type: application/json' -d '{"status":"Approved"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b52b310d2c8325bb75e0c7145021ff