### PR TITLE
feat: add endpoint for next application id

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A comprehensive web-based leave management system designed for small to medium o
 - **Status Tracking**: View application status and history
 - **Real-time Notifications**: Get notified when applications are approved or rejected
 - **Balance Checking**: Automatic validation against available leave balance
+- **Application ID Preview**: Retrieve the next unique application ID via `/api/next_application_id`
 
 ### 🔐 For Administrators
 - **Employee Management**: Add, edit, and manage employee records

--- a/script.js
+++ b/script.js
@@ -874,6 +874,7 @@ async function updateEmployeeInfo() {
     } else {
         let previewId = generatePreviewApplicationId();
         try {
+            // Request a server-generated ID for consistency with stored applications
             const resp = await fetch('/api/next_application_id');
             if (resp.ok) {
                 const data = await resp.json();

--- a/server.py
+++ b/server.py
@@ -105,6 +105,12 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
     
     def handle_get_request(self, collection, path_parts, query_string):
         """Handle GET requests"""
+        if collection == 'next_application_id':
+            # Generate unique application ID similar to creation logic
+            next_id = f"APP-{datetime.now().strftime('%Y%m%d')}-{uuid.uuid4().hex[:8].upper()}"
+            self.send_json_response({'application_id': next_id})
+            return
+
         with db_lock:
             conn = get_db_connection()
             try:


### PR DESCRIPTION
## Summary
- allow clients to fetch the next unique application id via `/api/next_application_id`
- document and annotate application id preview behavior in client code

## Testing
- `python -m py_compile server.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5a9275314832596f9f74e98f9bcde