### PR TITLE
Serialize balance updates with database lock

### DIFF
--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -32,95 +32,96 @@ def initialize_employee_balances(employee_id, year=None):
     
     for attempt in range(MAX_DB_INIT_RETRIES):
         conn = None
-        try:
-            if DETAILED_BALANCE_INIT_LOGGING and attempt > 0:
-                print(f"🔄 Balance initialization attempt {attempt + 1}/{MAX_DB_INIT_RETRIES} for employee {employee_id}")
-            
-            conn = get_db_connection()
-            current_time = datetime.now().isoformat()
-            
-            # Get employee details with better error handling
-            cursor = conn.execute('SELECT annual_leave, sick_leave, first_name, surname FROM employees WHERE id = ? AND is_active = 1', (employee_id,))
-            employee = cursor.fetchone()
-            
-            if not employee:
-                raise ValueError(f"Employee {employee_id} not found in database")
-            
-            if DETAILED_BALANCE_INIT_LOGGING:
-                print(f"✅ Found employee for balance init: {employee['first_name']} {employee['surname']}")
-            
-            privilege_allocation = employee['annual_leave'] or DEFAULT_PRIVILEGE_LEAVE
-            sick_allocation = employee['sick_leave'] or DEFAULT_SICK_LEAVE
-            
-            # Check if balances already exist
-            existing_cursor = conn.execute('''
-                SELECT COUNT(*) as count FROM leave_balances 
-                WHERE employee_id = ? AND year = ?
-            ''', (employee_id, year))
-            
-            existing_count = existing_cursor.fetchone()['count']
-            
-            if existing_count > 0:
+        with db_lock:
+            try:
+                if DETAILED_BALANCE_INIT_LOGGING and attempt > 0:
+                    print(f"🔄 Balance initialization attempt {attempt + 1}/{MAX_DB_INIT_RETRIES} for employee {employee_id}")
+
+                conn = get_db_connection()
+                current_time = datetime.now().isoformat()
+
+                # Get employee details with better error handling
+                cursor = conn.execute('SELECT annual_leave, sick_leave, first_name, surname FROM employees WHERE id = ? AND is_active = 1', (employee_id,))
+                employee = cursor.fetchone()
+
+                if not employee:
+                    raise ValueError(f"Employee {employee_id} not found in database")
+
                 if DETAILED_BALANCE_INIT_LOGGING:
-                    print(f"ℹ️ Leave balances already exist for employee {employee_id} (year {year})")
-                conn.close()
+                    print(f"✅ Found employee for balance init: {employee['first_name']} {employee['surname']}")
+
+                privilege_allocation = employee['annual_leave'] or DEFAULT_PRIVILEGE_LEAVE
+                sick_allocation = employee['sick_leave'] or DEFAULT_SICK_LEAVE
+
+                # Check if balances already exist
+                existing_cursor = conn.execute('''
+                    SELECT COUNT(*) as count FROM leave_balances
+                    WHERE employee_id = ? AND year = ?
+                ''', (employee_id, year))
+
+                existing_count = existing_cursor.fetchone()['count']
+
+                if existing_count > 0:
+                    if DETAILED_BALANCE_INIT_LOGGING:
+                        print(f"ℹ️ Leave balances already exist for employee {employee_id} (year {year})")
+                    conn.close()
+                    return True
+
+                # Initialize privilege leave balance
+                conn.execute('''
+                    INSERT OR REPLACE INTO leave_balances
+                    (id, employee_id, balance_type, allocated_days, used_days, remaining_days, year, last_updated, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (
+                    str(uuid.uuid4()),
+                    employee_id,
+                    'PRIVILEGE',
+                    privilege_allocation,
+                    0,
+                    privilege_allocation,
+                    year,
+                    current_time,
+                    current_time
+                ))
+
+                # Initialize sick leave balance
+                conn.execute('''
+                    INSERT OR REPLACE INTO leave_balances
+                    (id, employee_id, balance_type, allocated_days, used_days, remaining_days, year, last_updated, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (
+                    str(uuid.uuid4()),
+                    employee_id,
+                    'SICK',
+                    sick_allocation,
+                    0,
+                    sick_allocation,
+                    year,
+                    current_time,
+                    current_time
+                ))
+
+                conn.commit()
+
+                if DETAILED_BALANCE_INIT_LOGGING:
+                    print(f"✅ Successfully initialized leave balances for employee {employee_id}")
+
                 return True
-            
-            # Initialize privilege leave balance
-            conn.execute('''
-                INSERT OR REPLACE INTO leave_balances 
-                (id, employee_id, balance_type, allocated_days, used_days, remaining_days, year, last_updated, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (
-                str(uuid.uuid4()),
-                employee_id,
-                'PRIVILEGE',
-                privilege_allocation,
-                0,
-                privilege_allocation,
-                year,
-                current_time,
-                current_time
-            ))
-            
-            # Initialize sick leave balance
-            conn.execute('''
-                INSERT OR REPLACE INTO leave_balances 
-                (id, employee_id, balance_type, allocated_days, used_days, remaining_days, year, last_updated, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (
-                str(uuid.uuid4()),
-                employee_id,
-                'SICK',
-                sick_allocation,
-                0,
-                sick_allocation,
-                year,
-                current_time,
-                current_time
-            ))
-            
-            conn.commit()
-            
-            if DETAILED_BALANCE_INIT_LOGGING:
-                print(f"✅ Successfully initialized leave balances for employee {employee_id}")
-            
-            return True
-            
-        except Exception as e:
-            if conn:
-                conn.rollback()
-            
-            if attempt >= MAX_DB_INIT_RETRIES - 1:
-                raise e
-            else:
-                if DETAILED_BALANCE_INIT_LOGGING:
-                    print(f"⚠️ Balance init attempt {attempt + 1} failed for employee {employee_id}: {e}")
-                time.sleep(DB_INIT_RETRY_DELAY)
-                
-        finally:
-            if conn:
-                conn.close()
+
+            except Exception as e:
+                if conn:
+                    conn.rollback()
+
+                if attempt >= MAX_DB_INIT_RETRIES - 1:
+                    raise e
+                else:
+                    if DETAILED_BALANCE_INIT_LOGGING:
+                        print(f"⚠️ Balance init attempt {attempt + 1} failed for employee {employee_id}: {e}")
+                    time.sleep(DB_INIT_RETRY_DELAY)
+
+            finally:
+                if conn:
+                    conn.close()
     
     return False
 
@@ -129,120 +130,128 @@ def update_leave_balance(employee_id, balance_type, change_amount, reason, appli
     if not AUTO_UPDATE_BALANCES:
         return False
     
-    conn = get_db_connection()
-    try:
-        current_time = datetime.now().isoformat()
-        current_year = datetime.now().year
-        
-        # Get current balance
-        cursor = conn.execute('''
-            SELECT * FROM leave_balances 
-            WHERE employee_id = ? AND balance_type = ? AND year = ?
-        ''', (employee_id, balance_type, current_year))
-        
-        balance_record = cursor.fetchone()
-        
-        if not balance_record:
-            # Initialize balance if it doesn't exist
-            initialize_employee_balances(employee_id, current_year)
+    current_time = datetime.now().isoformat()
+    current_year = datetime.now().year
+
+    balance_record = None
+    with db_lock:
+        conn = get_db_connection()
+        try:
             cursor = conn.execute('''
-                SELECT * FROM leave_balances 
+                SELECT * FROM leave_balances
                 WHERE employee_id = ? AND balance_type = ? AND year = ?
             ''', (employee_id, balance_type, current_year))
             balance_record = cursor.fetchone()
-        
-        if not balance_record:
-            raise ValueError(f"Could not initialize balance for employee {employee_id}")
-        
-        previous_used = balance_record['used_days']
-        previous_remaining = balance_record['remaining_days']
-        
-        new_used = previous_used + change_amount
-        new_remaining = balance_record['allocated_days'] + balance_record['carryforward_days'] - new_used
-        
-        # Check for negative balance prevention
-        if PREVENT_NEGATIVE_BALANCES and new_remaining < 0:
-            raise ValueError(f"Insufficient {balance_type.lower()} leave balance. Required: {change_amount}, Available: {previous_remaining}")
-        
-        # Update balance
-        conn.execute('''
-            UPDATE leave_balances 
-            SET used_days = ?, remaining_days = ?, last_updated = ?
-            WHERE employee_id = ? AND balance_type = ? AND year = ?
-        ''', (new_used, new_remaining, current_time, employee_id, balance_type, current_year))
-        
-        # Create audit record
-        if ENABLE_BALANCE_AUDIT:
+        finally:
+            conn.close()
+
+    if not balance_record:
+        initialize_employee_balances(employee_id, current_year)
+        with db_lock:
+            conn = get_db_connection()
+            try:
+                cursor = conn.execute('''
+                    SELECT * FROM leave_balances
+                    WHERE employee_id = ? AND balance_type = ? AND year = ?
+                ''', (employee_id, balance_type, current_year))
+                balance_record = cursor.fetchone()
+            finally:
+                conn.close()
+
+    if not balance_record:
+        raise ValueError(f"Could not initialize balance for employee {employee_id}")
+
+    previous_used = balance_record['used_days']
+    previous_remaining = balance_record['remaining_days']
+
+    new_used = previous_used + change_amount
+    new_remaining = balance_record['allocated_days'] + balance_record['carryforward_days'] - new_used
+
+    if PREVENT_NEGATIVE_BALANCES and new_remaining < 0:
+        raise ValueError(f"Insufficient {balance_type.lower()} leave balance. Required: {change_amount}, Available: {previous_remaining}")
+
+    with db_lock:
+        conn = get_db_connection()
+        try:
             conn.execute('''
-                INSERT INTO leave_balance_history 
-                (id, employee_id, balance_type, change_type, change_amount, previous_balance, new_balance, reason, application_id, changed_by, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (
-                str(uuid.uuid4()),
-                employee_id,
-                balance_type,
-                'DEDUCTION' if change_amount > 0 else 'ADDITION',
-                abs(change_amount),
-                previous_remaining,
-                new_remaining,
-                reason,
-                application_id,
-                changed_by,
-                current_time
-            ))
-        
-        conn.commit()
-        
-        return True
-        
-    except Exception as e:
-        conn.rollback()
-        raise e
-    finally:
-        conn.close()
+                UPDATE leave_balances
+                SET used_days = ?, remaining_days = ?, last_updated = ?
+                WHERE employee_id = ? AND balance_type = ? AND year = ?
+            ''', (new_used, new_remaining, current_time, employee_id, balance_type, current_year))
+
+            if ENABLE_BALANCE_AUDIT:
+                conn.execute('''
+                    INSERT INTO leave_balance_history
+                    (id, employee_id, balance_type, change_type, change_amount, previous_balance, new_balance, reason, application_id, changed_by, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (
+                    str(uuid.uuid4()),
+                    employee_id,
+                    balance_type,
+                    'DEDUCTION' if change_amount > 0 else 'ADDITION',
+                    abs(change_amount),
+                    previous_remaining,
+                    new_remaining,
+                    reason,
+                    application_id,
+                    changed_by,
+                    current_time
+                ))
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
+            raise e
+        finally:
+            conn.close()
+
+    return True
 
 def process_leave_application_balance(application_id, new_status, changed_by='SYSTEM'):
     """Adjust leave balances when an application's status changes."""
-    conn = get_db_connection()
-    try:
-        # Fetch application details
-        cursor = conn.execute(
-            'SELECT employee_id, leave_type, total_days FROM leave_applications WHERE id = ?',
-            (application_id,),
-        )
-        application = cursor.fetchone()
-        if not application:
-            raise ValueError(f"Leave application {application_id} not found")
+    employee_id = None
+    balance_type = None
+    total_days = 0
+    last_action = None
+    balance_exists = None
+    current_year = datetime.now().year
 
-        employee_id = application['employee_id']
-        leave_type = application['leave_type']
-        total_days = float(application['total_days'])
+    with db_lock:
+        conn = get_db_connection()
+        try:
+            cursor = conn.execute(
+                'SELECT employee_id, leave_type, total_days FROM leave_applications WHERE id = ?',
+                (application_id,),
+            )
+            application = cursor.fetchone()
+            if not application:
+                raise ValueError(f"Leave application {application_id} not found")
 
-        # Determine which balance to adjust
-        balance_type = 'PRIVILEGE' if leave_type in PRIVILEGE_LEAVE_TYPES else 'SICK'
+            employee_id = application['employee_id']
+            leave_type = application['leave_type']
+            total_days = float(application['total_days'])
 
-        # Ensure balance exists for employee
-        current_year = datetime.now().year
-        cursor = conn.execute(
-            'SELECT id FROM leave_balances WHERE employee_id = ? AND balance_type = ? AND year = ?',
-            (employee_id, balance_type, current_year),
-        )
-        if not cursor.fetchone():
-            initialize_employee_balances(employee_id, current_year)
+            balance_type = 'PRIVILEGE' if leave_type in PRIVILEGE_LEAVE_TYPES else 'SICK'
 
-        # Check latest balance action for this application
-        cursor = conn.execute(
-            'SELECT change_type FROM leave_balance_history WHERE application_id = ? ORDER BY created_at DESC LIMIT 1',
-            (application_id,),
-        )
-        last_action = cursor.fetchone()
-    finally:
-        conn.close()
+            cursor = conn.execute(
+                'SELECT id FROM leave_balances WHERE employee_id = ? AND balance_type = ? AND year = ?',
+                (employee_id, balance_type, current_year),
+            )
+            balance_exists = cursor.fetchone()
+
+            cursor = conn.execute(
+                'SELECT change_type FROM leave_balance_history WHERE application_id = ? ORDER BY created_at DESC LIMIT 1',
+                (application_id,),
+            )
+            last_action = cursor.fetchone()
+        finally:
+            conn.close()
+
+    if not balance_exists:
+        initialize_employee_balances(employee_id, current_year)
 
     reason = f"Leave application status changed to {new_status}"
 
     if new_status == 'Approved':
-        # Deduct days only if not already deducted
         if not last_action or last_action['change_type'] != 'DEDUCTION':
             update_leave_balance(
                 employee_id,
@@ -253,7 +262,6 @@ def process_leave_application_balance(application_id, new_status, changed_by='SY
                 changed_by=changed_by,
             )
     else:
-        # Restore days if previously deducted
         if last_action and last_action['change_type'] == 'DEDUCTION':
             update_leave_balance(
                 employee_id,
@@ -268,21 +276,21 @@ def process_leave_application_balance(application_id, new_status, changed_by='SY
 
 def get_employee_balances(employee_id=None):
     """Get employee balances with optional filtering"""
-    conn = get_db_connection()
-    try:
-        if employee_id:
-            cursor = conn.execute(
-                'SELECT * FROM leave_balances WHERE employee_id = ? ORDER BY balance_type, year',
-                (employee_id,)
-            )
-        else:
-            cursor = conn.execute('SELECT * FROM leave_balances ORDER BY employee_id, balance_type')
-        
-        results = [dict(row) for row in cursor.fetchall()]
-        return results
-        
-    finally:
-        conn.close()
+    with db_lock:
+        conn = get_db_connection()
+        try:
+            if employee_id:
+                cursor = conn.execute(
+                    'SELECT * FROM leave_balances WHERE employee_id = ? ORDER BY balance_type, year',
+                    (employee_id,)
+                )
+            else:
+                cursor = conn.execute('SELECT * FROM leave_balances ORDER BY employee_id, balance_type')
+
+            results = [dict(row) for row in cursor.fetchall()]
+            return results
+        finally:
+            conn.close()
 
 # @tweakable: The name of the person or system making manual balance edits.
 MANUAL_EDIT_ACTOR_NAME = "Admin"
@@ -296,49 +304,48 @@ def update_balances_from_admin_edit(employee_id, new_remaining_pl, new_remaining
     if not ADMIN_CAN_EDIT_REMAINING_LEAVE:
         return
 
-    conn = get_db_connection()
-    try:
-        current_time = datetime.now().isoformat()
-        current_year = datetime.now().year
+    with db_lock:
+        conn = get_db_connection()
+        try:
+            current_time = datetime.now().isoformat()
+            current_year = datetime.now().year
 
-        # --- Update Privilege Leave ---
-        cursor_pl = conn.execute(
-            'SELECT id, remaining_days, used_days, allocated_days FROM leave_balances WHERE employee_id = ? AND balance_type = "PRIVILEGE" AND year = ?',
-            (employee_id, current_year)
-        )
-        current_pl = cursor_pl.fetchone()
-        
-        if current_pl and float(current_pl['remaining_days']) != float(new_remaining_pl):
-            # Recalculate used_days based on the new remaining balance
-            new_used_pl = current_pl['allocated_days'] - float(new_remaining_pl)
-            
-            conn.execute(
-                'UPDATE leave_balances SET remaining_days = ?, used_days = ?, last_updated = ? WHERE id = ?',
-                (new_remaining_pl, new_used_pl, current_time, current_pl['id'])
+            # --- Update Privilege Leave ---
+            cursor_pl = conn.execute(
+                'SELECT id, remaining_days, used_days, allocated_days FROM leave_balances WHERE employee_id = ? AND balance_type = "PRIVILEGE" AND year = ?',
+                (employee_id, current_year)
             )
+            current_pl = cursor_pl.fetchone()
 
-        # --- Update Sick Leave ---
-        cursor_sl = conn.execute(
-            'SELECT id, remaining_days, used_days, allocated_days FROM leave_balances WHERE employee_id = ? AND balance_type = "SICK" AND year = ?',
-            (employee_id, current_year)
-        )
-        current_sl = cursor_sl.fetchone()
+            if current_pl and float(current_pl['remaining_days']) != float(new_remaining_pl):
+                new_used_pl = current_pl['allocated_days'] - float(new_remaining_pl)
 
-        if current_sl and float(current_sl['remaining_days']) != float(new_remaining_sl):
-            # Recalculate used_days
-            new_used_sl = current_sl['allocated_days'] - float(new_remaining_sl)
-            
-            conn.execute(
-                'UPDATE leave_balances SET remaining_days = ?, used_days = ?, last_updated = ? WHERE id = ?',
-                (new_remaining_sl, new_used_sl, current_time, current_sl['id'])
+                conn.execute(
+                    'UPDATE leave_balances SET remaining_days = ?, used_days = ?, last_updated = ? WHERE id = ?',
+                    (new_remaining_pl, new_used_pl, current_time, current_pl['id'])
+                )
+
+            # --- Update Sick Leave ---
+            cursor_sl = conn.execute(
+                'SELECT id, remaining_days, used_days, allocated_days FROM leave_balances WHERE employee_id = ? AND balance_type = "SICK" AND year = ?',
+                (employee_id, current_year)
             )
+            current_sl = cursor_sl.fetchone()
 
-        conn.commit()
-    except Exception as e:
-        conn.rollback()
-        raise e
-    finally:
-        conn.close()
+            if current_sl and float(current_sl['remaining_days']) != float(new_remaining_sl):
+                new_used_sl = current_sl['allocated_days'] - float(new_remaining_sl)
+
+                conn.execute(
+                    'UPDATE leave_balances SET remaining_days = ?, used_days = ?, last_updated = ? WHERE id = ?',
+                    (new_remaining_sl, new_used_sl, current_time, current_sl['id'])
+                )
+
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
+            raise e
+        finally:
+            conn.close()
 
 def _todo():
     """Placeholder to keep the module importable."""


### PR DESCRIPTION
## Summary
- serialize balance initialization with database lock
- guard leave balance updates and admin edits with db lock and proper connection cleanup
- add lock-based handling when processing leave applications and retrieving balances

## Testing
- `python - <<'PY'
from services.database_service import init_database, get_db_connection
from services.employee_service import create_employee
from services.balance_manager import initialize_employee_balances, process_leave_application_balance, update_balances_from_admin_edit, get_employee_balances
from datetime import datetime
import uuid

init_database()

# create employee
emp = create_employee({'first_name':'John','surname':'Doe','personal_email':'john.doe@example.com','annual_leave':15,'sick_leave':7})
emp_id = emp['id']
print('Created employee', emp_id)

# initialize balances
initialize_employee_balances(emp_id)
print('Initialized balances', get_employee_balances(emp_id))

# create leave application and approve
conn = get_db_connection()
try:
    app_id = str(uuid.uuid4())
    conn.execute('INSERT INTO leave_applications (id, application_id, employee_id, employee_name, start_date, end_date, leave_type, total_days, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
                 (app_id, app_id, emp_id, 'John Doe', '2024-01-01', '2024-01-02', 'Annual Leave', 2, 'Pending'))
    conn.commit()
finally:
    conn.close()

process_leave_application_balance(app_id, 'Approved', changed_by='tester')
print('Balances after approval', get_employee_balances(emp_id))

# admin edit
update_balances_from_admin_edit(emp_id, new_remaining_pl=10, new_remaining_sl=5)
print('Balances after admin edit', get_employee_balances(emp_id))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b5a8e73ca483258af65ee95da76913