### PR TITLE
Avoid deadlock when initializing balances

### DIFF
--- a/services/database_service.py
+++ b/services/database_service.py
@@ -16,7 +16,8 @@ MAX_DB_RETRIES = 3
 DB_CONNECTION_TIMEOUT = 30
 
 # Database lock for thread safety
-db_lock = threading.Lock()
+# Use RLock to allow the same thread to re-acquire the lock safely
+db_lock = threading.RLock()
 
 def get_db_connection():
     """Get database connection with retry logic"""


### PR DESCRIPTION
## Summary
- use `threading.RLock` for database access so the same thread can safely re-acquire the lock
- call `initialize_employee_balances` after releasing the database lock in `handle_post_request`

## Testing
- `python -m py_compile services/database_service.py server.py`
- `python server.py 8090`
- `curl -X POST -H "Content-Type: application/json" -d '{"first_name":"Test","surname":"User","personal_email":"test@example.com"}' http://localhost:8090/api/employee`
- `curl http://localhost:8090/api/employee`
- `curl "http://localhost:8090/api/leave_balance?employee_id=0df8afab-2980-4346-8a81-8d76b29a6207"`


------
https://chatgpt.com/codex/tasks/task_e_68b5acec3b1083259682b9e1b75f6cf5