### PR TITLE
Enable concurrent request handling

### DIFF
--- a/server.py
+++ b/server.py
@@ -671,7 +671,7 @@ def run_server(port=8080):
         print("📊 Initializing database...")
         init_database()
         
-        with socketserver.TCPServer(("", port), LeaveManagementHandler) as httpd:
+        with socketserver.ThreadingTCPServer(("", port), LeaveManagementHandler) as httpd:
             print(f"Server running at http://localhost:{port}")
             print("Press Ctrl+C to stop the server")
             httpd.serve_forever()


### PR DESCRIPTION
## Summary
- Use `socketserver.ThreadingTCPServer` in `run_server` for multi-threaded request handling

## Testing
- `python -m py_compile server.py`
- Started the server and performed concurrent leave application and approval requests

------
https://chatgpt.com/codex/tasks/task_e_68b5b288efcc832587342872c7f2fc59