### PR TITLE
Add calendar attachments for approved leave emails

### DIFF
--- a/server.py
+++ b/server.py
@@ -25,9 +25,11 @@ from services.balance_manager import (
 )
 from services.email_service import (
     send_notification_email,
+    generate_ics_content,
     SMTP_SERVER,
     SMTP_PORT,
     SMTP_USERNAME,
+    SMTP_PASSWORD,
 )
 
 # @tweakable server configuration
@@ -493,6 +495,18 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                     f"({total_days} days) has been {status_word}."
                                 )
 
+                                ics_content = None
+                                if new_status == 'Approved':
+                                    ics_content = generate_ics_content(
+                                        start_date,
+                                        end_date,
+                                        summary=f"Leave for {employee_name}",
+                                        description=(
+                                            f"Approved leave from {start_date} to {end_date} "
+                                            f"({total_days} days)"
+                                        ),
+                                    )
+
                                 try:
                                     send_notification_email(
                                         ADMIN_EMAIL,
@@ -502,6 +516,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                         SMTP_PORT,
                                         SMTP_USERNAME,
                                         SMTP_PASSWORD,
+                                        ics_content=ics_content,
                                     )
                                 except Exception as email_err:
                                     print(f"⚠️ Failed to notify manager for {record_id}: {email_err}")
@@ -516,6 +531,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                             SMTP_PORT,
                                             SMTP_USERNAME,
                                             SMTP_PASSWORD,
+                                            ics_content=ics_content,
                                         )
                                     except Exception as email_err:
                                         print(f"⚠️ Failed to notify employee {employee_id}: {email_err}")

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -4,6 +4,8 @@ Service: Email Service. Purpose: Send notifications and alerts via SMTP.
 
 import os
 import smtplib
+import uuid
+from datetime import datetime, timedelta
 from email.message import EmailMessage
 
 
@@ -16,6 +18,51 @@ SMTP_USERNAME = os.getenv("SMTP_USERNAME", "qtaskvacation@gmail.com")
 SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "bicg llyb myff kigu")
 
 
+def generate_ics_content(
+    start_date: str,
+    end_date: str,
+    summary: str,
+    description: str | None = None,
+) -> str:
+    """Create a basic ICS calendar event.
+
+    Parameters
+    ----------
+    start_date, end_date:
+        Dates in ISO ``YYYY-MM-DD`` format. ``end_date`` is treated as
+        inclusive and will be incremented by one day for the ICS ``DTEND``
+        field which is exclusive.
+    summary:
+        Event title shown on the calendar entry.
+    description:
+        Optional description to include with the event.
+    """
+
+    start_dt = datetime.fromisoformat(start_date)
+    end_dt = datetime.fromisoformat(end_date) + timedelta(days=1)
+    uid = f"{uuid.uuid4()}@leave-management-system"
+    dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Leave Management System//EN",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{dtstamp}",
+        f"DTSTART;VALUE=DATE:{start_dt.strftime('%Y%m%d')}",
+        f"DTEND;VALUE=DATE:{end_dt.strftime('%Y%m%d')}",
+        f"SUMMARY:{summary}",
+    ]
+
+    if description:
+        lines.append(f"DESCRIPTION:{description}")
+
+    lines.extend(["END:VEVENT", "END:VCALENDAR"])
+
+    return "\r\n".join(lines)
+
+
 def send_notification_email(
     to_addr: str,
     subject: str,
@@ -24,6 +71,7 @@ def send_notification_email(
     smtp_port: int = SMTP_PORT,
     username: str | None = None,
     password: str | None = None,
+    ics_content: str | None = None,
 ) -> bool:
     """Send notification email via SMTP with configurable settings."""
 
@@ -37,6 +85,13 @@ def send_notification_email(
     msg["To"] = to_addr
     msg["Subject"] = subject
     msg.set_content(body)
+
+    if ics_content:
+        msg.add_attachment(
+            ics_content,
+            subtype="calendar",
+            filename="event.ics",
+        )
 
     try:
         with smtplib.SMTP(smtp_server, smtp_port) as s:


### PR DESCRIPTION
## Summary
- add `generate_ics_content` helper to build basic calendar events
- allow `send_notification_email` to optionally attach an ICS file
- send ICS calendar invites to managers and employees when leave is approved

## Testing
- `python -m py_compile services/email_service.py server.py`
- `python - <<'PY'
from services.email_service import send_notification_email, generate_ics_content
ics = generate_ics_content('2024-01-01', '2024-01-02', 'Test Event')
print(ics.splitlines()[0])
print('ICS length:', len(ics))
res = send_notification_email(
    'noreply@example.com',
    'Test',
    'Body',
    smtp_server='localhost',
    smtp_port=1025,
    username='user',
    password='pass',
    ics_content=ics,
)
print('Result:', res)
PY` (fails: [Errno 111] Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68b5be62572c832592270c1dea9a478c