### PR TITLE
feat: display remaining leave balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,23 +87,24 @@
                         <span id="employeeDisplayName">Please log in first</span>
                         <small id="applicationIdPreview" style="display: block; color: #64748b; margin-top: 5px;">Application ID will be generated upon submission</small>
                     </div>
-                    <!-- Leave Balance Display -->
-                    <div id="leaveBalanceDisplay" class="leave-balance-display" style="display: none;">
-                        <h3>📊 Available Leave Balance</h3>
-                        <div class="balance-row">
-                            <div class="balance-item privilege-leave">
-                                <span class="balance-label">🏖️ Privilege Leave (PL):</span>
-                                <span class="balance-value" id="privilegeLeaveBalance">-- days</span>
-                            </div>
-                            <div class="balance-item sick-leave">
-                                <span class="balance-label">🤒 Sick Leave (SL):</span>
-                                <span class="balance-value" id="sickLeaveBalance">-- days</span>
-                            </div>
-                        </div>
-                        <small class="balance-note" id="balanceUpdateNote">Balance updates automatically when leave requests are approved.</small>
-                    </div>
                 </div>
             </section>
+
+            <!-- Leave Balance Display moved above Vacation Dates -->
+            <div id="leaveBalanceDisplay" class="leave-balance-display" style="display: none;">
+                <h3>📊 Available Leave Balance</h3>
+                <div class="balance-row">
+                    <div class="balance-item privilege-leave">
+                        <span class="balance-label">🏖️ Privilege Leave (PL):</span>
+                        <span class="balance-value" id="privilegeLeaveBalance">-- days</span>
+                    </div>
+                    <div class="balance-item sick-leave">
+                        <span class="balance-label">🤒 Sick Leave (SL):</span>
+                        <span class="balance-value" id="sickLeaveBalance">-- days</span>
+                    </div>
+                </div>
+                <small class="balance-note" id="balanceUpdateNote">Balance updates automatically when leave requests are approved.</small>
+            </div>
 
             <form id="vacationForm" class="vacation-form">
                 <!-- Date Selection Section -->

--- a/script.js
+++ b/script.js
@@ -885,6 +885,42 @@ async function updateEmployeeInfo() {
         }
         idPreviewEl.textContent = previewId;
     }
+
+    // Update leave balance display for logged in employee
+    if (currentUser && currentUser.id) {
+        await updateLeaveBalanceDisplay();
+    }
+}
+
+// Fetch and render remaining leave balances for the current employee
+async function updateLeaveBalanceDisplay() {
+    const container = document.getElementById('leaveBalanceDisplay');
+    if (!currentUser || !container) {
+        return;
+    }
+
+    try {
+        const resp = await fetch(`/api/leave_balance?employee_id=${currentUser.id}`);
+        if (!resp.ok) throw new Error('Failed to fetch leave balances');
+        const balances = await resp.json();
+
+        const priv = balances.find(b => b.balance_type === 'PRIVILEGE');
+        const sick = balances.find(b => b.balance_type === 'SICK');
+
+        const privEl = document.getElementById('privilegeLeaveBalance');
+        const sickEl = document.getElementById('sickLeaveBalance');
+        if (privEl) {
+            privEl.textContent = priv ? `${priv.remaining_days} days` : '-- days';
+        }
+        if (sickEl) {
+            sickEl.textContent = sick ? `${sick.remaining_days} days` : '-- days';
+        }
+
+        container.style.display = 'block';
+    } catch (err) {
+        console.error('Error loading leave balances:', err);
+        container.style.display = 'none';
+    }
 }
 
 async function loginEmployee(email) {


### PR DESCRIPTION
## Summary
- show remaining privilege and sick leave balances on employee login
- fetch balance data from backend API and render in leave request form
- move leave balance card above vacation date selector

## Testing
- `python -m py_compile server.py services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c484785083259fcd653332e20c74