### PR TITLE
Handle multi-select leave types

### DIFF
--- a/script.js
+++ b/script.js
@@ -1268,8 +1268,9 @@ async function submitLeaveApplication(event) {
         
         const formData = new FormData(event.target);
         const leaveTypes = Array.from(document.querySelectorAll('input[name="leaveType"]:checked'))
-            .map(cb => cb.value);
-        
+            // Use checkbox values as canonical leave type codes
+            .map(cb => cb.value.trim());
+
     const applicationData = {
         employee_id: currentUser.id,
         employee_name: `${currentUser.first_name} ${currentUser.surname}`,
@@ -1277,7 +1278,8 @@ async function submitLeaveApplication(event) {
         end_date: formData.get('endDate'),
         start_day_type: formData.get('startDayType'),
         end_day_type: formData.get('endDayType'),
-        leave_type: leaveTypes.join(', '),
+        // Store comma-separated canonical codes for backend processing
+        leave_type: leaveTypes.join(','),
         selected_reasons: leaveTypes,
         reason: formData.get('reason'),
         total_days: calculateTotalDays(

--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -13,7 +13,9 @@ import time
 AUTO_UPDATE_BALANCES = True
 PREVENT_NEGATIVE_BALANCES = True
 ENABLE_BALANCE_AUDIT = True
-PRIVILEGE_LEAVE_TYPES = {'Annual Leave', 'Vacation / Annual Leave', 'Personal Leave'}
+# Checkbox values that map to privilege leave
+# These correspond to the `value` attributes in index.html
+PRIVILEGE_LEAVE_TYPES = {'personal', 'vacation-annual'}
 ADMIN_CAN_EDIT_REMAINING_LEAVE = True
 DEFAULT_PRIVILEGE_LEAVE = 15
 DEFAULT_SICK_LEAVE = 7
@@ -230,7 +232,13 @@ def process_leave_application_balance(application_id, new_status, changed_by='SY
             leave_type = application['leave_type']
             total_days = float(application['total_days'])
 
-            balance_type = 'PRIVILEGE' if leave_type in PRIVILEGE_LEAVE_TYPES else 'SICK'
+            # `leave_type` may contain multiple comma-separated codes
+            leave_tokens = [t.strip() for t in leave_type.split(',') if t.strip()]
+            balance_type = (
+                'PRIVILEGE'
+                if any(t in PRIVILEGE_LEAVE_TYPES for t in leave_tokens)
+                else 'SICK'
+            )
 
             cursor = conn.execute(
                 'SELECT id FROM leave_balances WHERE employee_id = ? AND balance_type = ? AND year = ?',


### PR DESCRIPTION
## Summary
- align privilege leave codes with frontend checkbox values
- handle comma-separated leave types when adjusting balances
- send canonical leave type codes from the frontend

## Testing
- `python -m py_compile services/balance_manager.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5d1c18ce88325b0624eaca6e71f5f