### PR TITLE
Remove calendar functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,10 +379,6 @@
                             </tbody>
                         </table>
                     </div>
-                    <div class="section">
-                        <h2>Approved Leave Calendar</h2>
-                        <div id="leaveCalendar"></div>
-                    </div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -1385,7 +1385,6 @@ async function loadLeaveApplications() {
             tbody.appendChild(row);
         }
 
-        await loadApprovedLeaves();
     } catch (error) {
         console.error('Error loading leave applications:', error);
     }
@@ -1401,7 +1400,6 @@ async function updateApplicationStatus(id, newStatus) {
     try {
         await room.collection('leave_application').update(id, { status: newStatus });
         await loadLeaveApplications();
-        await loadApprovedLeaves();
         alert('Application status updated successfully');
     } catch (error) {
         const requestUrl = `leave_application/${id}`;
@@ -1431,57 +1429,6 @@ async function updateApplicationStatus(id, newStatus) {
     }
 }
 
-async function loadApprovedLeaves() {
-    try {
-        const events = await room.collection('approved_leave').getList();
-        renderLeaveCalendar(events);
-    } catch (error) {
-        console.error('Error loading approved leaves:', error);
-    }
-}
-
-function renderLeaveCalendar(events) {
-    const calendar = document.getElementById('leaveCalendar');
-    if (!calendar) return;
-    calendar.innerHTML = '';
-
-    events.forEach(ev => {
-        const item = document.createElement('div');
-        item.className = 'calendar-event';
-        item.innerHTML = `
-            <span>${ev.employee_id}: ${ev.start_date} - ${ev.end_date}</span>
-            <button class="edit-event">Edit</button>
-            <button class="delete-event">Remove</button>
-        `;
-        calendar.appendChild(item);
-
-        const editBtn = item.querySelector('.edit-event');
-        if (editBtn) {
-            editBtn.addEventListener('click', async () => {
-                const newStart = prompt('New start date', ev.start_date);
-                const newEnd = prompt('New end date', ev.end_date);
-                if (newStart && newEnd) {
-                    await room.collection('approved_leave').update(ev.id, { start_date: newStart, end_date: newEnd });
-                    await loadApprovedLeaves();
-                }
-            });
-        }
-
-        const deleteBtn = item.querySelector('.delete-event');
-        if (deleteBtn) {
-            deleteBtn.addEventListener('click', async () => {
-                if (confirm('Remove this event?')) {
-                    await room.collection('approved_leave').delete(ev.id);
-                    await loadApprovedLeaves();
-                }
-            });
-        }
-    });
-
-    if (events.length === 0) {
-        calendar.textContent = 'No approved leave events';
-    }
-}
 
 async function loadLeaveHistory(employeeId) {
     try {

--- a/styles.css
+++ b/styles.css
@@ -567,6 +567,7 @@ tr:hover {
     font-weight: 500;
 }
 
+
 .status-pending {
     background: #fef3c7;
     color: #92400e;
@@ -1107,12 +1108,4 @@ tr:hover {
     border-radius: 4px;
     font-size: 0.8rem;
     font-weight: 500;
-}
-
-.calendar-event {
-    margin: 5px 0;
-}
-
-.calendar-event button {
-    margin-left: 5px;
 }


### PR DESCRIPTION
## Summary
- drop calendar event refresh from application workflows
- delete unused calendar functions and markup
- clean up calendar-specific styling

## Testing
- `npm test` (fails: ENOENT could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d86ac5bc8325b4b53feb0a4dbb32