### PR TITLE
chore: remove legacy filter ui

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,12 +354,6 @@
                 </div>
                 <div class="section">
                     <h2>Leave Application Status</h2>
-                    <div class="status-filters">
-                        <button class="filter-btn active" data-status="all">All</button>
-                        <button class="filter-btn" data-status="Pending">Pending</button>
-                        <button class="filter-btn" data-status="Approved">Approved</button>
-                        <button class="filter-btn" data-status="Rejected">Rejected</button>
-                    </div>
                     <div class="table-container">
                         <table id="applicationsTable">
                             <thead>

--- a/script.js
+++ b/script.js
@@ -459,10 +459,6 @@ document.addEventListener('DOMContentLoaded', function() {
         deleteAllBtn.addEventListener('click', deleteAllEmployees);
     }
 
-    document.querySelectorAll('.filter-btn').forEach(btn => {
-        btn.addEventListener('click', () => filterApplications(btn.dataset.status));
-    });
-
     const exportBackupBtn = document.getElementById('exportBackupBtn');
     if (exportBackupBtn) {
         exportBackupBtn.addEventListener('click', exportDatabaseBackup);
@@ -1625,22 +1621,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-let currentApplicationStatus = 'all';
-
-function filterApplications(status) {
-    currentApplicationStatus = status;
-
-    document.querySelectorAll('.filter-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.status === status);
-    });
-
-    document.querySelectorAll('#applicationsTableBody tr').forEach(row => {
-        const rowStatus = row.dataset.status;
-        const showRow = status === 'all' || rowStatus === status;
-        row.style.display = showRow ? '' : 'none';
-    });
-}
-
 function exportDatabaseBackup() {
     console.warn('exportDatabaseBackup is not implemented yet.');
 }
@@ -1658,7 +1638,6 @@ window.deleteEmployee = deleteEmployee;
 window.deleteAllEmployees = deleteAllEmployees;
 window.closeErrorModal = closeErrorModal;
 window.closeEditModal = closeEditModal;
-window.filterApplications = filterApplications;
 window.exportDatabaseBackup = exportDatabaseBackup;
 window.importDatabaseBackup = importDatabaseBackup;
 window.updateApplicationStatus = updateApplicationStatus;

--- a/styles.css
+++ b/styles.css
@@ -528,36 +528,6 @@ tr:hover {
     100% { transform: rotate(360deg); }
 }
 
-/* Status Filters */
-.status-filters {
-    display: flex;
-    gap: 10px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-}
-
-.filter-btn {
-    padding: 8px 16px;
-    border: 2px solid var(--border-color);
-    background: var(--surface);
-    color: var(--text-primary);
-    border-radius: var(--border-radius);
-    cursor: pointer;
-    font-size: 0.9rem;
-    font-weight: 500;
-    transition: all 0.2s ease;
-}
-
-.filter-btn:hover {
-    background: var(--background);
-    border-color: var(--primary-color);
-}
-
-.filter-btn.active {
-    background: var(--primary-color);
-    color: white;
-    border-color: var(--primary-color);
-}
 
 /* Status badges */
 .status-badge {


### PR DESCRIPTION
## Summary
- remove unused filterApplications handler and filter button listeners
- drop old filter UI markup and associated styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d93c5a088325b0b6ffcfaf0f9b8e