### PR TITLE
Filter leave applications by status

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,22 +96,29 @@ class BackendCollection {
         }
     }
 
-    async getList() {
+    async getList(params = {}) {
+        const queryString = new URLSearchParams(params).toString();
         try {
-            // Check cache validity
+            // Check cache validity for unfiltered requests
             const now = Date.now();
-            if (this.cachedData.length > 0 && now - this.lastFetchTime < this.cacheTimeout) {
+            if (!queryString && this.cachedData.length > 0 && now - this.lastFetchTime < this.cacheTimeout) {
                 return this.applyFilters(this.cachedData);
             }
-            
-            const data = await this.makeRequest('GET');
-            this.cachedData = data || [];
-            this.lastFetchTime = now;
-            
-            return this.applyFilters(this.cachedData);
+
+            const data = await this.makeRequest('GET', queryString ? `?${queryString}` : '');
+            if (!queryString) {
+                this.cachedData = data || [];
+                this.lastFetchTime = now;
+                return this.applyFilters(this.cachedData);
+            }
+
+            return this.applyFilters(data || []);
         } catch (error) {
             console.error(`Error fetching ${this.name}:`, error);
-            return this.applyFilters(this.cachedData); // Return cached data on error
+            if (!queryString) {
+                return this.applyFilters(this.cachedData); // Return cached data on error for unfiltered requests
+            }
+            return this.applyFilters([]);
         }
     }
 
@@ -1339,7 +1346,7 @@ function calculateTotalDays(startDate, endDate, startDayType, endDayType) {
 
 async function loadLeaveApplications() {
     try {
-        const applications = await room.collection('leave_application').getList();
+        const applications = await room.collection('leave_application').getList({ status: 'Pending' });
 
         const tbody = document.getElementById('applicationsTableBody');
         if (!tbody) {

--- a/server.py
+++ b/server.py
@@ -144,14 +144,20 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                     results = [dict(row) for row in cursor.fetchall()]
                     
                 elif collection == 'leave_application':
-                    # Get leave applications with optional employee filter
+                    # Get leave applications with optional employee and status filters
+                    base_query = 'SELECT * FROM leave_applications'
+                    conditions = []
+                    params = []
                     if 'employee_id' in query:
-                        cursor = conn.execute(
-                            'SELECT * FROM leave_applications WHERE employee_id = ? ORDER BY created_at DESC',
-                            (query['employee_id'][0],)
-                        )
-                    else:
-                        cursor = conn.execute('SELECT * FROM leave_applications ORDER BY created_at DESC')
+                        conditions.append('employee_id = ?')
+                        params.append(query['employee_id'][0])
+                    if 'status' in query:
+                        conditions.append('status = ?')
+                        params.append(query['status'][0])
+                    if conditions:
+                        base_query += ' WHERE ' + ' AND '.join(conditions)
+                    base_query += ' ORDER BY created_at DESC'
+                    cursor = conn.execute(base_query, tuple(params))
                     results = [dict(row) for row in cursor.fetchall()]
                 elif collection == 'holiday':
                     cursor = conn.execute('SELECT * FROM holidays ORDER BY date')


### PR DESCRIPTION
## Summary
- allow GET /leave_application to filter by optional status parameter
- fetch only pending leave applications on frontend using new query option

## Testing
- `python -m py_compile server.py services/*.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5d9dfc9188325bd2709c04ff77db0