### PR TITLE
Reorder application status and add employee summary search

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,26 +333,6 @@
         <div id="application-status" class="tab-content">
             <div class="admin-panel">
                 <div class="section">
-                    <h2>Employee Leave Summary</h2>
-                    <div class="table-container">
-                        <table id="employeeStatusTable">
-                            <thead>
-                                <tr>
-                                    <th>Employee</th>
-                                    <th>Privilege Allocated</th>
-                                    <th>Privilege Used</th>
-                                    <th>Privilege Remaining</th>
-                                    <th>Sick Allocated</th>
-                                    <th>Sick Used</th>
-                                    <th>Sick Remaining</th>
-                                    <th>Active Requests</th>
-                                </tr>
-                            </thead>
-                            <tbody id="employeeStatusTableBody"></tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="section">
                     <h2>Leave Application Status</h2>
                     <div class="table-container">
                         <table id="applicationsTable">
@@ -376,6 +356,27 @@
                     <div class="section">
                         <h2>Approved Leave Calendar</h2>
                         <div id="leaveCalendar"></div>
+                    </div>
+                </div>
+                <div class="section">
+                    <h2>Employee Leave Summary</h2>
+                    <input type="text" id="employeeSearch" placeholder="Search employee">
+                    <div class="table-container">
+                        <table id="employeeStatusTable">
+                            <thead>
+                                <tr>
+                                    <th>Employee</th>
+                                    <th>Privilege Allocated</th>
+                                    <th>Privilege Used</th>
+                                    <th>Privilege Remaining</th>
+                                    <th>Sick Allocated</th>
+                                    <th>Sick Used</th>
+                                    <th>Sick Remaining</th>
+                                    <th>Active Requests</th>
+                                </tr>
+                            </thead>
+                            <tbody id="employeeStatusTableBody"></tbody>
+                        </table>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1404,6 +1404,9 @@ async function loadEmployeeSummary() {
             room.collection('leave_application').getList()
         ]);
 
+        const searchInput = document.getElementById('employeeSearch');
+        const filter = searchInput ? searchInput.value.trim().toLowerCase() : '';
+
         const summary = new Map();
 
         employees.forEach(emp => {
@@ -1477,7 +1480,9 @@ async function loadEmployeeSummary() {
         }
         tbody.innerHTML = '';
 
+        let hasRows = false;
         for (const info of summary.values()) {
+            if (filter && !info.name.toLowerCase().includes(filter)) continue;
             const row = document.createElement('tr');
             row.innerHTML = `
                 <td>${info.name}</td>
@@ -1490,9 +1495,10 @@ async function loadEmployeeSummary() {
                 <td>${info.activeRequests}</td>
             `;
             tbody.appendChild(row);
+            hasRows = true;
         }
 
-        if (summary.size === 0) {
+        if (!hasRows) {
             const row = document.createElement('tr');
             row.innerHTML = '<td colspan="8">No employee data found</td>';
             tbody.appendChild(row);
@@ -1737,6 +1743,13 @@ document.addEventListener('DOMContentLoaded', function() {
         closeModalBtn.addEventListener('click', function() {
             document.getElementById('successModal').classList.remove('show');
         });
+    }
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+    const searchInput = document.getElementById('employeeSearch');
+    if (searchInput) {
+        searchInput.addEventListener('input', loadEmployeeSummary);
     }
 });
 


### PR DESCRIPTION
## Summary
- Reorder Application Status and Employee Leave Summary sections so status appears first
- Add employee search bar to filter the leave summary
- Implement client-side filtering logic and live search handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb1c7b208325b1ef2e69ee1b38bd