### PR TITLE
Allow negative leave balances when exceeding allocation

### DIFF
--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -11,7 +11,7 @@ import time
 # Moved from server.py - balance management functions
 # @tweakable balance management configuration
 AUTO_UPDATE_BALANCES = True
-PREVENT_NEGATIVE_BALANCES = True
+PREVENT_NEGATIVE_BALANCES = False
 ENABLE_BALANCE_AUDIT = True
 # Checkbox values that map to privilege leave
 # These correspond to the `value` attributes in index.html


### PR DESCRIPTION
## Summary
- disable balance protection to permit negative remaining days

## Testing
- `python -m py_compile services/balance_manager.py`
- `python - <<'PY' ...` (approve leave exceeding allocation -> negative balance)


------
https://chatgpt.com/codex/tasks/task_e_68b6004479108325a20e7332d0dd8e52