### PR TITLE
Ensure zero remaining leave balances stay zero

### DIFF
--- a/script.js
+++ b/script.js
@@ -1428,10 +1428,10 @@ async function loadEmployeeSummary() {
         });
 
         summary.forEach(info => {
-            if (info.privilegeAllocated && !info.privilegeRemaining) {
+            if (info.privilegeAllocated && info.privilegeRemaining == null) {
                 info.privilegeRemaining = info.privilegeAllocated - info.privilegeUsed;
             }
-            if (info.sickAllocated && !info.sickRemaining) {
+            if (info.sickAllocated && info.sickRemaining == null) {
                 info.sickRemaining = info.sickAllocated - info.sickUsed;
             }
         });


### PR DESCRIPTION
## Summary
- Prevent zero leave balances from being recalculated as negatives by checking for null/undefined before computing remaining privilege or sick leave

## Testing
- `node --check script.js`
- `node - <<'NODE'
const summary = new Map([[1,{privilegeAllocated:10, privilegeUsed:10, privilegeRemaining:0, sickAllocated:10, sickUsed:10, sickRemaining:0}]]);
summary.forEach(info => {
  if (info.privilegeAllocated && info.privilegeRemaining == null) {
    info.privilegeRemaining = info.privilegeAllocated - info.privilegeUsed;
  }
  if (info.sickAllocated && info.sickRemaining == null) {
    info.sickRemaining = info.sickAllocated - info.sickUsed;
  }
});
console.log('PL', summary.get(1).privilegeRemaining, 'SL', summary.get(1).sickRemaining);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b60042c49c8325a6b1daa3ea70faa8