### PR TITLE
Handle case-insensitive leave types in summary

### DIFF
--- a/script.js
+++ b/script.js
@@ -1408,7 +1408,9 @@ async function loadEmployeeSummary() {
             const info = summary.get(app.employee_id);
             if (!info) return;
 
-            const types = (app.leave_type || '').split(',').map(t => t.trim().toUpperCase());
+            const types = (app.leave_type || '')
+                .split(',')
+                .map(t => t.trim().toLowerCase());
             const days = parseFloat(app.total_days) || 0;
 
             if (app.status === 'Pending') {
@@ -1417,10 +1419,13 @@ async function loadEmployeeSummary() {
             }
 
             if (app.status === 'Approved') {
+                const privilegeTypes = ['privilege', 'pl', 'vacation-annual', 'personal'];
+                const sickTypes = ['sick', 'sl'];
+
                 types.forEach(t => {
-                    if (t === 'PRIVILEGE' || t === 'PL') {
+                    if (privilegeTypes.includes(t)) {
                         info.privilegeUsed += days;
-                    } else if (t === 'SICK' || t === 'SL') {
+                    } else if (sickTypes.includes(t)) {
                         info.sickUsed += days;
                     }
                 });


### PR DESCRIPTION
## Summary
- Normalize leave types before evaluating summary data.
- Count `vacation-annual` and `personal` leave as privileged while preserving existing privilege and sick leave mappings.

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6001cb68c83259290faf175bc74ed