### PR TITLE
Highlight exhausted leave balances

### DIFF
--- a/script.js
+++ b/script.js
@@ -1452,14 +1452,16 @@ async function loadEmployeeSummary() {
         for (const info of summary.values()) {
             if (filter && !info.name.toLowerCase().includes(filter)) continue;
             const row = document.createElement('tr');
+            const pClass = info.privilegeRemaining <= 0 ? "remaining-alert" : "";
+            const sClass = info.sickRemaining <= 0 ? "remaining-alert" : "";
             row.innerHTML = `
                 <td>${info.name}</td>
                 <td>${info.privilegeAllocated}</td>
                 <td>${info.privilegeUsed}</td>
-                <td>${info.privilegeRemaining}</td>
+                <td class="${pClass}">${info.privilegeRemaining}</td>
                 <td>${info.sickAllocated}</td>
                 <td>${info.sickUsed}</td>
-                <td>${info.sickRemaining}</td>
+                <td class="${sClass}">${info.sickRemaining}</td>
                 <td>${info.activeRequests}</td>
             `;
             tbody.appendChild(row);

--- a/styles.css
+++ b/styles.css
@@ -1086,3 +1086,7 @@ tr:hover {
 .calendar-event button {
     margin-left: 5px;
 }
+
+.remaining-alert {
+    color: var(--error-color); /* #dc2626 */
+}


### PR DESCRIPTION
## Summary
- Flag zero or negative leave balances in the summary table with a red highlight
- Add styling for `remaining-alert` class to show exhausted balances in error color

## Testing
- `node --check script.js`
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b606174cd0832599cc0ba2247bc7c7