### PR TITLE
Add admin logout endpoint and client logout call

### DIFF
--- a/script.js
+++ b/script.js
@@ -962,6 +962,17 @@ async function loginAdmin(username, password) {
     }
 }
 
+async function logoutAdmin() {
+    try {
+        await fetch('/api/logout_admin', {
+            method: 'POST',
+            credentials: 'include'
+        });
+    } catch (error) {
+        console.error('Error logging out admin:', error);
+    }
+}
+
 function showMainApp() {
     document.getElementById('entryContainer').style.display = 'none';
     document.getElementById('employeeLoginContainer').style.display = 'none';
@@ -1016,7 +1027,11 @@ function displayWelcome() {
     }
 }
 
-function logout() {
+async function logout() {
+    if (currentUserType === 'admin') {
+        await logoutAdmin();
+    }
+
     currentUserType = null;
     currentUser = null;
     sessionToken = null;


### PR DESCRIPTION
## Summary
- add `/api/logout_admin` endpoint to drop admin session tokens and clear the cookie
- introduce `logoutAdmin` in the client and invoke it from `logout`

## Testing
- `python -m py_compile server.py services/*.py`
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60fc719448325b448b4b8805a5cdb