### PR TITLE
Remove admin token from login flow

### DIFF
--- a/script.js
+++ b/script.js
@@ -934,28 +934,31 @@ async function loginEmployee(email) {
 }
 
 async function loginAdmin(username, password) {
-    /* @tweakable admin login credentials */
-    const validAdminUsername = 'admin';
-    const validAdminPassword = 'admin123';
-    
     try {
         showLoading();
-        
-        if (username === validAdminUsername && password === validAdminPassword) {
-            currentUserType = 'admin';
-            currentUser = { username: username, first_name: 'Administrator', email: 'admin@company.com' };
 
-            sessionToken = 'admin-token';
-            sessionStorage.setItem(AUTH_TYPE_KEY, currentUserType);
-            sessionStorage.setItem(AUTH_USER_KEY, JSON.stringify(currentUser));
-            sessionStorage.setItem(AUTH_TOKEN_KEY, sessionToken);
-            
-            hideLoading();
-            showMainApp();
-        } else {
-            throw new Error('Invalid credentials');
+        const response = await fetch('/api/login_admin', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password })
+        });
+
+        if (!response.ok) {
+            throw new Error(`Login failed: ${response.status}`);
         }
-        
+
+        await response.json();
+
+        currentUserType = 'admin';
+        currentUser = { username: username, first_name: 'Administrator', email: 'admin@company.com' };
+        sessionToken = null;
+
+        sessionStorage.setItem(AUTH_TYPE_KEY, currentUserType);
+        sessionStorage.setItem(AUTH_USER_KEY, JSON.stringify(currentUser));
+
+        hideLoading();
+        showMainApp();
+
     } catch (error) {
         hideLoading();
         alert(`Login failed: ${error.message}`);

--- a/server.py
+++ b/server.py
@@ -53,6 +53,8 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
     def do_POST(self):
         if self.path == '/api/bootstrap_employee':
             self.handle_bootstrap_employee()
+        elif self.path == '/api/login_admin':
+            self.handle_login_admin()
         elif self.path.startswith('/api/'):
             self.handle_api_request()
         else:
@@ -606,6 +608,27 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
         self.send_cors_headers()
         error_message = message if message else self.responses.get(code, ('', ''))[0]
         self._safe_write(json.dumps({'error': error_message}).encode('utf-8'))
+
+    def handle_login_admin(self):
+        """Handle admin login requests and return a success message without a token."""
+        try:
+            content_length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(content_length) if content_length else b'{}'
+            data = json.loads(body.decode('utf-8'))
+
+            username = data.get('username', '').strip()
+            password = data.get('password', '').strip()
+
+            valid_username = 'admin'
+            valid_password = 'admin123'
+
+            if username == valid_username and password == valid_password:
+                self.send_json_response({'message': 'Login successful'})
+            else:
+                self.send_error(401, 'Invalid credentials')
+
+        except Exception as e:
+            self.send_error(500, f'Login failed: {str(e)}')
     
     def handle_bootstrap_employee(self):
         """Initialize per-employee data/balances on login with enhanced error handling"""


### PR DESCRIPTION
## Summary
- Drop token from admin login endpoint and just confirm success
- Update frontend admin login to stop expecting a token

## Testing
- `python -m py_compile server.py services/*.py`
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60fcba59883258fc722968efd0b28