### PR TITLE
Implement leave balance reset capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,6 +308,9 @@
                     <button id="deleteAllBtn" type="button" class="btn btn-danger" style="margin-bottom: 15px;">
                         🗑️ Delete All Employees
                     </button>
+                    <button id="resetBalancesBtn" type="button" class="btn btn-warning">
+                      ♻️ Reset All Leave Balances
+                    </button>
                     <div class="table-container">
                         <table id="employeeTable">
                             <thead>

--- a/script.js
+++ b/script.js
@@ -435,6 +435,8 @@ document.addEventListener('DOMContentLoaded', function() {
     if (deleteAllBtn) {
         deleteAllBtn.addEventListener('click', deleteAllEmployees);
     }
+    const resetBtn = document.getElementById('resetBalancesBtn');
+    if (resetBtn) resetBtn.addEventListener('click', resetAllLeaveBalances);
 
     const exportBackupBtn = document.getElementById('exportBackupBtn');
     if (exportBackupBtn) {
@@ -1763,7 +1765,8 @@ async function deleteAllEmployees() {
 async function resetAllLeaveBalances() {
     if (confirm('Are you sure you want to reset all leave balances? This action cannot be undone.')) {
         try {
-            await fetch('/api/leave_balance/reset_all', { method: 'POST' });
+            const resp = await fetch('/api/reset_balances', { method: 'POST' });
+            if (!resp.ok) throw new Error('Request failed');
             await loadEmployeeList();
             await loadEmployeeSummary();
             alert('All leave balances reset successfully');


### PR DESCRIPTION
## Summary
- add reset_all_balances utility to regenerate annual leave balances for all active staff
- expose POST /api/reset_balances endpoint protected by admin cookie token
- introduce admin UI control and JS handler to trigger balance reset

## Testing
- `python -m py_compile services/balance_manager.py server.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b61cbba9ac8325b4288db408f0746b