### PR TITLE
Allow Authorization header in CORS

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,7 +48,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
         """Add CORS headers to the response"""
         self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 
     def do_OPTIONS(self):
         """Handle CORS preflight requests"""


### PR DESCRIPTION
## Summary
- permit Authorization header in CORS responses

## Testing
- `python -m py_compile server.py`
- `curl -X POST http://localhost:8080/api/employee -H 'Content-Type: application/json' -H 'Authorization: Bearer testtoken' -d '{"first_name":"John","surname":"Doe","personal_email":"john@example.com"}'`
- `curl -i -X OPTIONS http://localhost:8080/api/employee/0474a87c-c7b7-472b-b24f-1f1720cd4720 -H 'Access-Control-Request-Method: PUT' -H 'Access-Control-Request-Headers: Content-Type, Authorization'`
- `curl -X PUT http://localhost:8080/api/employee/0474a87c-c7b7-472b-b24f-1f1720cd4720 -H 'Content-Type: application/json' -H 'Authorization: Bearer testtoken' -d '{"first_name":"Johnny"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b621245f60832590d50575bd58840e