### PR TITLE
Improve backend request timeout handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,9 +48,11 @@ class BackendCollection {
         const url = `${this.database.baseUrl}/${this.name}${path}`;
         
         for (let attempt = 1; attempt <= this.database.maxRetries; attempt++) {
+            let controller;
+            let timeoutId;
             try {
-                const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), this.database.requestTimeout);
+                controller = new AbortController();
+                timeoutId = setTimeout(() => controller.abort(), this.database.requestTimeout);
 
                 const options = {
                     method: method,
@@ -89,6 +91,15 @@ class BackendCollection {
                 return result;
                 
             } catch (error) {
+                if (timeoutId) {
+                    clearTimeout(timeoutId);
+                }
+
+                if (error.name === 'AbortError') {
+                    console.error(`⏱️ ${method} ${url} timed out after ${this.database.requestTimeout}ms`);
+                    error = new Error(`Request timed out after ${this.database.requestTimeout}ms`);
+                }
+
                 if (attempt === this.database.maxRetries) {
                     console.error(`❌ ${method} ${url} failed after ${attempt} attempts:`, error);
                     throw error;


### PR DESCRIPTION
## Summary
- handle `AbortError` separately in `BackendCollection.makeRequest` to log clear timeout messages and avoid dangling timers

## Testing
- `node --check script.js`
- `python server.py` then `curl http://localhost:8080/api/employee/12345`


------
https://chatgpt.com/codex/tasks/task_e_68b623f1d2bc83259a6eb93a4da2b441