### PR TITLE
Validate Content-Length header in PUT requests

### DIFF
--- a/server.py
+++ b/server.py
@@ -377,7 +377,10 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
         record_id = path_parts[3]
         
         try:
-            content_length = int(self.headers['Content-Length'])
+            content_length = int(self.headers.get('Content-Length', 0))
+            if content_length <= 0:
+                self.send_error(400, "Content-Length header missing or zero")
+                return
             post_data = self.rfile.read(content_length)
             data = json.loads(post_data.decode('utf-8'))
             


### PR DESCRIPTION
## Summary
- Safely retrieve Content-Length header when handling PUT requests
- Return a 400 error if Content-Length is missing or zero to prevent invalid updates

## Testing
- `python -m py_compile server.py`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68b6294341c88325bedf70b0612332f8