### PR TITLE
Require admin token for holiday modifications

### DIFF
--- a/server.py
+++ b/server.py
@@ -219,6 +219,17 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
             reset_all_balances()
             self.send_json_response({'status': 'balances reset'})
             return
+        if collection == 'holiday':
+            cookie_header = self.headers.get('Cookie', '')
+            token = None
+            if cookie_header:
+                cookie = SimpleCookie()
+                cookie.load(cookie_header)
+                if 'admin_token' in cookie:
+                    token = cookie['admin_token'].value
+            if not token or token not in active_admin_tokens:
+                self.send_error(403, "Admin authentication required")
+                return
         try:
             content_length = int(self.headers.get('Content-Length', 0))
             post_data = self.rfile.read(content_length) if content_length > 0 else b''
@@ -374,9 +385,21 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
         if len(path_parts) < 4:
             self.send_error(400, "Record ID required for update")
             return
-        
+
         record_id = path_parts[3]
-        
+
+        if collection == 'holiday':
+            cookie_header = self.headers.get('Cookie', '')
+            token = None
+            if cookie_header:
+                cookie = SimpleCookie()
+                cookie.load(cookie_header)
+                if 'admin_token' in cookie:
+                    token = cookie['admin_token'].value
+            if not token or token not in active_admin_tokens:
+                self.send_error(403, "Admin authentication required")
+                return
+
         try:
             content_length = int(self.headers.get('Content-Length', 0))
             post_data = self.rfile.read(content_length) if content_length > 0 else b''
@@ -576,9 +599,21 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
         if len(path_parts) < 4:
             self.send_error(400, "Record ID required for delete")
             return
-        
+
         record_id = path_parts[3]
-        
+
+        if collection == 'holiday':
+            cookie_header = self.headers.get('Cookie', '')
+            token = None
+            if cookie_header:
+                cookie = SimpleCookie()
+                cookie.load(cookie_header)
+                if 'admin_token' in cookie:
+                    token = cookie['admin_token'].value
+            if not token or token not in active_admin_tokens:
+                self.send_error(403, "Admin authentication required")
+                return
+
         with db_lock:
             conn = get_db_connection()
             try:


### PR DESCRIPTION
## Summary
- enforce admin token validation when creating holidays
- guard holiday update and delete operations behind admin token

## Testing
- `python -m py_compile server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b62f2c1f8883259db7eb3980a55214