### PR TITLE
Allow admin auth restore without token

### DIFF
--- a/script.js
+++ b/script.js
@@ -731,15 +731,18 @@ function restoreAuthenticationState() {
         const savedUser = sessionStorage.getItem(AUTH_USER_KEY);
         const savedToken = sessionStorage.getItem(AUTH_TOKEN_KEY);
 
-        if (savedType && savedUser && savedToken) {
-            currentUserType = savedType;
-            currentUser = JSON.parse(savedUser);
-            sessionToken = savedToken;
+        if (savedType && savedUser) {
+            const canRestore = savedType === 'admin' || savedToken;
+            if (canRestore) {
+                currentUserType = savedType;
+                currentUser = JSON.parse(savedUser);
+                sessionToken = savedToken;
 
-            if (debugAuthRestore) {
-                console.log('✅ Authentication state restored:', { type: currentUserType, user: currentUser });
+                if (debugAuthRestore) {
+                    console.log('✅ Authentication state restored:', { type: currentUserType, user: currentUser });
+                }
+                showMainApp();
             }
-            showMainApp();
         }
     } catch (error) {
         console.error('Error restoring auth state:', error);


### PR DESCRIPTION
## Summary
- let admins resume sessions even without a saved token
- only restore non-admin sessions when a token is present
- display main app after state restoration

## Testing
- `node --check script.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b62f273f9883258bfc66c4778ae622