### PR TITLE
Add automatic holiday population for next fiscal year

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,6 +399,7 @@
                         </div>
                         <button type="submit" class="btn btn-primary">Add Holiday</button>
                     </form>
+                    <button type="button" id="populateHolidaysBtn" class="btn btn-secondary" style="margin-top: 10px;">Auto-Populate Next Fiscal Year Holidays</button>
                 </div>
                 <div class="section">
                     <h2>Holiday Dates List</h2>


### PR DESCRIPTION
## Summary
- Add Auto-Populate button to Holiday management page
- Implement client-side holiday population and table refresh with delete controls
- Provide server endpoint to reset and insert next fiscal year holidays in one request

## Testing
- `python -m py_compile server.py`
- `python -m py_compile services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b63025adec83259bc0ad1f845b9033