### PR TITLE
Relocate holiday autopopulate button and drop backup controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,13 +399,11 @@
                         </div>
                         <button type="submit" class="btn btn-primary">Add Holiday</button>
                     </form>
-                    <button type="button" id="populateHolidaysBtn" class="btn btn-secondary" style="margin-top: 10px;">Auto-Populate Next Fiscal Year Holidays</button>
                 </div>
                 <div class="section">
                     <h2>Holiday Dates List</h2>
                     <div style="margin-bottom: 15px;">
-                        <button id="exportBackupBtn" class="btn btn-secondary" style="margin-right: 10px;">📁 Export Backup</button>
-                        <button id="importBackupBtn" class="btn btn-secondary">📂 Import Backup</button>
+                        <button type="button" id="populateHolidaysBtn" class="btn btn-primary">Auto-Populate Next Fiscal Year Holidays</button>
                     </div>
                     <div class="table-container">
                         <table id="holidayTable">

--- a/script.js
+++ b/script.js
@@ -450,16 +450,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const resetBtn = document.getElementById('resetBalancesBtn');
     if (resetBtn) resetBtn.addEventListener('click', resetAllLeaveBalances);
 
-    const exportBackupBtn = document.getElementById('exportBackupBtn');
-    if (exportBackupBtn) {
-        exportBackupBtn.addEventListener('click', exportDatabaseBackup);
-    }
-
-    const importBackupBtn = document.getElementById('importBackupBtn');
-    if (importBackupBtn) {
-        importBackupBtn.addEventListener('click', importDatabaseBackup);
-    }
-
     const errorModalClose = document.getElementById('errorModalClose');
     if (errorModalClose) {
         errorModalClose.addEventListener('click', closeErrorModal);
@@ -1910,14 +1900,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-function exportDatabaseBackup() {
-    console.warn('exportDatabaseBackup is not implemented yet.');
-}
-
-function importDatabaseBackup() {
-    console.warn('importDatabaseBackup is not implemented yet.');
-}
-
 // Expose functions for inline handlers
 window.showEmployeeLogin = showEmployeeLogin;
 window.showAdminLogin = showAdminLogin;
@@ -1928,7 +1910,5 @@ window.deleteAllEmployees = deleteAllEmployees;
 window.resetAllLeaveBalances = resetAllLeaveBalances;
 window.closeErrorModal = closeErrorModal;
 window.closeEditModal = closeEditModal;
-window.exportDatabaseBackup = exportDatabaseBackup;
-window.importDatabaseBackup = importDatabaseBackup;
 window.updateApplicationStatus = updateApplicationStatus;
 window.loadEmployeeSummary = loadEmployeeSummary;


### PR DESCRIPTION
## Summary
- Move "Auto-Populate Next Fiscal Year Holidays" button under Holiday Dates List and style it primary blue
- Remove unused import/export backup buttons and supporting JavaScript

## Testing
- `node --check script.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b635c070d08325bb14c3f8668ba673