### PR TITLE
Skip weekends when calculating leave duration

### DIFF
--- a/script.js
+++ b/script.js
@@ -1445,7 +1445,9 @@ function calculateTotalDays(startDate, endDate, startDayType, endDayType) {
     const current = new Date(start);
     while (current <= end) {
         const iso = current.toISOString().split('T')[0];
-        if (!holidayDates.has(iso)) {
+        const day = current.getDay();
+        // Skip weekends (Saturday=6, Sunday=0)
+        if (day !== 0 && day !== 6 && !holidayDates.has(iso)) {
             total += 1;
             if (current.getTime() === start.getTime() && startType !== 'full') {
                 total -= 0.5;


### PR DESCRIPTION
## Summary
- Exclude weekends from client-side leave day calculations
- Recompute total_days server-side by excluding weekends and stored holidays

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b63e258f7083259c0608bd83304fc0