### PR TITLE
Remove delete-all employees feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,9 +305,6 @@
 
                 <div class="section">
                     <h2>Employee List</h2>
-                    <button id="deleteAllBtn" type="button" class="btn btn-danger" style="margin-bottom: 15px;">
-                        🗑️ Delete All Employees
-                    </button>
                     <button id="resetBalancesBtn" type="button" class="btn btn-warning">
                       ♻️ Reset All Leave Balances
                     </button>

--- a/script.js
+++ b/script.js
@@ -448,11 +448,6 @@ document.addEventListener('DOMContentLoaded', function() {
     if (tabHolidayDates) {
         tabHolidayDates.addEventListener('click', () => switchTab('holiday-dates'));
     }
-
-    const deleteAllBtn = document.getElementById('deleteAllBtn');
-    if (deleteAllBtn) {
-        deleteAllBtn.addEventListener('click', deleteAllEmployees);
-    }
     const resetBtn = document.getElementById('resetBalancesBtn');
     if (resetBtn) resetBtn.addEventListener('click', resetAllLeaveBalances);
 
@@ -1910,23 +1905,6 @@ async function deleteEmployee(employeeId) {
     }
 }
 
-async function deleteAllEmployees() {
-    if (confirm('Are you sure you want to delete ALL employees? This action cannot be undone.')) {
-        try {
-            const employees = await room.collection('employee').getList();
-            
-            for (const employee of employees) {
-                await room.collection('employee').delete(employee.id);
-            }
-            
-            await loadEmployeeList();
-            alert('All employees deleted successfully');
-        } catch (error) {
-            alert(`Error deleting employees: ${error.message}`);
-        }
-    }
-}
-
 async function resetAllLeaveBalances() {
     if (confirm('Are you sure you want to reset all leave balances? This action cannot be undone.')) {
         try {
@@ -1976,7 +1954,6 @@ window.showAdminLogin = showAdminLogin;
 window.switchTab = switchTab;
 window.editEmployee = editEmployee;
 window.deleteEmployee = deleteEmployee;
-window.deleteAllEmployees = deleteAllEmployees;
 window.resetAllLeaveBalances = resetAllLeaveBalances;
 window.closeErrorModal = closeErrorModal;
 window.closeEditModal = closeEditModal;


### PR DESCRIPTION
## Summary
- Remove Delete All Employees button from the Employee List section
- Delete `deleteAllEmployees` logic and window export

## Testing
- `timeout 2 python server.py`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6423fd1f08325bd4d182f0050844f