### PR TITLE
Use radio buttons for leave type selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,63 +157,63 @@
                 <section class="form-section">
                     <h2>📋 Reason for Time Off</h2>
                     <div class="leave-types">
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="personal">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="personal">
                             <span class="checkmark"></span>
                             Personal Leave
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="sick">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="sick">
                             <span class="checkmark"></span>
                             Sick Leave
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="family-emergency">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="family-emergency">
                             <span class="checkmark"></span>
                             Family Emergency
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="medical-appointment">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="medical-appointment">
                             <span class="checkmark"></span>
                             Medical Appointment
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="vacation-annual">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="vacation-annual">
                             <span class="checkmark"></span>
                             Vacation / Annual Leave
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="bereavement">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="bereavement">
                             <span class="checkmark"></span>
                             Bereavement / Funeral
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="maternity-paternity">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="maternity-paternity">
                             <span class="checkmark"></span>
                             Maternity / Paternity Leave
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="study-exam">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="study-exam">
                             <span class="checkmark"></span>
                             Study / Exam Leave
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="childcare">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="childcare">
                             <span class="checkmark"></span>
                             Childcare / Dependent Care
                         </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" name="leaveType" value="jury-duty">
+                        <label class="option-label">
+                            <input type="radio" name="leaveType" value="jury-duty">
                             <span class="checkmark"></span>
                             Jury Duty / Legal Obligation
                         </label>
-                        <label class="checkbox-label" id="leaveWithoutPayContainer" style="display: none;">
-                            <input type="checkbox" name="leaveType" value="leave-without-pay" id="leaveWithoutPayCheckbox">
+                        <label class="option-label" id="leaveWithoutPayContainer" style="display: none;">
+                            <input type="radio" name="leaveType" value="leave-without-pay" id="leaveWithoutPayCheckbox">
                             <span class="checkmark"></span>
                             Leave Without Pay
                         </label>
-                        <label class="checkbox-label" id="otherLeaveType">
-                            <input type="checkbox" name="leaveType" value="other">
+                        <label class="option-label" id="otherLeaveType">
+                            <input type="radio" name="leaveType" value="other">
                             <span class="checkmark"></span>
                             Other (please specify under "Reason for Leave")
                         </label>

--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -234,12 +234,11 @@ def process_leave_application_balance(application_id, new_status, changed_by='SY
             leave_type = application['leave_type']
             total_days = float(application['total_days'])
 
-            # `leave_type` may contain multiple comma-separated codes. Normalize tokens
-            # to lowercase to ensure case-insensitive matching against configured types.
-            leave_tokens = [t.strip().lower() for t in leave_type.split(',') if t.strip()]
+            # Normalize the single leave type to lowercase for matching
+            leave_token = (leave_type or '').strip().lower()
             balance_type = (
                 'PRIVILEGE'
-                if any(t in PRIVILEGE_LEAVE_TYPES for t in leave_tokens)
+                if leave_token in PRIVILEGE_LEAVE_TYPES
                 else 'SICK'
             )
 

--- a/styles.css
+++ b/styles.css
@@ -127,7 +127,7 @@ header p {
     margin-bottom: 20px;
 }
 
-.checkbox-label {
+.option-label {
     display: flex;
     align-items: center;
     gap: 10px;
@@ -137,11 +137,10 @@ header p {
     transition: background-color 0.2s ease;
 }
 
-.checkbox-label:hover {
+.option-label:hover {
     background-color: var(--background);
 }
-
-.checkbox-label input[type="checkbox"] {
+.option-label input[type="radio"] {
     width: 18px;
     height: 18px;
     accent-color: var(--primary-color);
@@ -153,7 +152,7 @@ header p {
     color: var(--text-primary);
 }
 
-.checkbox-label input[type="checkbox"]:checked + .checkmark {
+.option-label input[type="radio"]:checked + .checkmark {
     color: var(--primary-color);
     font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- Replace leave type checkboxes with radio buttons to restrict selection to a single reason
- Rename checkbox-label styles to option-label and apply to radio inputs
- Send single leave_type value from frontend and adjust balance manager to handle strings

## Testing
- `python -m py_compile server.py services/balance_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68b645be7ac48325973018ca7afe3eef