### PR TITLE
Add service length selector and auto-fill privilege leave

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,12 +290,23 @@
                         
                         <div class="form-row">
                             <div class="form-group">
+                                <label for="serviceLength">Length of Service</label>
+                                <select id="serviceLength" name="serviceLength">
+                                    <option value="1-3">1–3 Years</option>
+                                    <option value="4-7">4–7 Years</option>
+                                    <option value="8+">8+ Years</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="form-group">
                                 <label for="annualLeave">Privilege Leave (PL) (days)</label>
-                                <input type="number" id="annualLeave" name="annualLeave" min="0" max="45" value="15" required>
+                                <input type="number" id="annualLeave" name="annualLeave" min="0" max="45" required readonly>
                             </div>
                             <div class="form-group">
                                 <label for="sickLeave">Sick Leave (SL) (days)</label>
-                                <input type="number" id="sickLeave" name="sickLeave" min="0" max="15" value="7" required>
+                                <input type="number" id="sickLeave" name="sickLeave" min="0" max="15" value="5" required>
                             </div>
                         </div>
                         

--- a/script.js
+++ b/script.js
@@ -575,6 +575,20 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
+function updatePrivilegeLeave(rangeId, targetId) {
+    const range = document.getElementById(rangeId);
+    const target = document.getElementById(targetId);
+    if (!range || !target) return;
+
+    const mapping = {
+        '1-3': 5,
+        '4-7': 10,
+        '8+': 15
+    };
+
+    target.value = mapping[range.value] || '';
+}
+
 // **NEW: Set up critical form handlers immediately to prevent race condition**
 function setupCriticalFormHandlers() {
     /* @tweakable whether to enable immediate form handler setup debugging */
@@ -600,6 +614,17 @@ function setupCriticalFormHandlers() {
         
         if (debugImmediateSetup) {
             console.log('✅ Employee form submit handler attached immediately');
+        }
+
+        const serviceLengthSelect = document.getElementById('serviceLength');
+        if (serviceLengthSelect) {
+            serviceLengthSelect.addEventListener('change', function() {
+                updatePrivilegeLeave('serviceLength', 'annualLeave');
+            });
+
+            if (debugImmediateSetup) {
+                console.log('✅ Service length change handler attached immediately');
+            }
         }
     }
     
@@ -1177,7 +1202,7 @@ async function handleEmployeeFormSubmit() {
         surname: formData.get('surname'),
         personal_email: formData.get('personalEmail'),
         annual_leave: parseInt(formData.get('annualLeave')) || 15,
-        sick_leave: parseInt(formData.get('sickLeave')) || 7
+        sick_leave: parseInt(formData.get('sickLeave')) || 5
     };
     
     try {


### PR DESCRIPTION
## Summary
- Add Length of Service dropdown to employee creation form and auto-fill privilege leave based on selection
- Make privilege leave field read-only and default sick leave to 5 days
- Provide utility to map service length ranges to privilege leave and wire up change listener

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8f88284e88325834f4bfeda32a2eb