### PR TITLE
Add service length selector to edit employee form

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,8 +480,17 @@
                     <div class="form-row">
                         <div class="form-group">
                             <label for="editAnnualLeave">Privilege Leave (PL) (days)</label>
-                            <input type="number" id="editAnnualLeave" name="editAnnualLeave" min="0" max="45" required>
+                            <input type="number" id="editAnnualLeave" name="editAnnualLeave" min="0" max="45" required readonly>
                         </div>
+                        <div class="form-group">
+                            <label for="editServiceLength">Service Length</label>
+                            <select id="editServiceLength" name="editServiceLength">
+                                <option value="1-3">1–3 years</option>
+                                <option value="4-7">4–7 years</option>
+                                <option value="8+">8+ years</option>
+                            </select>
+                        </div>
+        
                         <div class="form-group">
                             <label for="editSickLeave">Sick Leave (SL) (days)</label>
                             <input type="number" id="editSickLeave" name="editSickLeave" min="0" max="15" required>

--- a/script.js
+++ b/script.js
@@ -362,6 +362,12 @@ window.LeaveBalanceAPI = {
     }
 };
 
+const SERVICE_LENGTH_MAP = {
+    '1-3': 5,
+    '4-7': 10,
+    '8+': 15
+};
+
 // Handle login and app initialization
 document.addEventListener('DOMContentLoaded', function() {
     /* @tweakable whether to show debug messages during login flow initialization */
@@ -664,6 +670,15 @@ function setupCriticalFormHandlers() {
                 alert(`Error updating employee: ${error.message}`);
             }
         });
+
+        const editServiceLength = document.getElementById('editServiceLength');
+        if (editServiceLength) {
+            editServiceLength.addEventListener('change', function() {
+                const annualInput = document.getElementById('editAnnualLeave');
+                const mapped = SERVICE_LENGTH_MAP[this.value];
+                annualInput.value = mapped !== undefined ? mapped : '';
+            });
+        }
 
         if (debugImmediateSetup) {
             console.log('✅ Edit employee form submit handler attached immediately');
@@ -1872,6 +1887,17 @@ async function editEmployee(employeeId) {
         document.getElementById('editPersonalEmail').value = employee.personal_email || '';
         document.getElementById('editAnnualLeave').value = employee.annual_leave || 0;
         document.getElementById('editSickLeave').value = employee.sick_leave || 0;
+
+        const serviceSelect = document.getElementById('editServiceLength');
+        if (serviceSelect) {
+            let lengthValue = '8+';
+            if (employee.annual_leave === 5) {
+                lengthValue = '1-3';
+            } else if (employee.annual_leave === 10) {
+                lengthValue = '4-7';
+            }
+            serviceSelect.value = lengthValue;
+        }
 
         const balances = await LeaveBalanceAPI.getEmployeeBalances(employeeId);
         const priv = balances.find(b => b.balance_type === 'PRIVILEGE');


### PR DESCRIPTION
## Summary
- Add service length dropdown in edit employee modal and make annual leave read-only
- Map service length to privilege leave and update value on change
- Populate service length select based on employee's current leave when editing

## Testing
- `node --check script.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8f886cc7c8325b05483993740362d