### PR TITLE
Combine leave form rows and unify input/select styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,9 +297,6 @@
                                     <option value="8+">8+ Years</option>
                                 </select>
                             </div>
-                        </div>
-
-                        <div class="form-row">
                             <div class="form-group">
                                 <label for="annualLeave">Privilege Leave (PL) (days)</label>
                                 <input type="number" id="annualLeave" name="annualLeave" min="0" max="45" required readonly>

--- a/styles.css
+++ b/styles.css
@@ -298,7 +298,8 @@ header p {
     color: var(--text-primary);
 }
 
-.form-group input {
+.form-group input,
+.form-group select {
     padding: 12px;
     border: 2px solid var(--border-color);
     border-radius: var(--border-radius);
@@ -306,7 +307,8 @@ header p {
     transition: border-color 0.2s ease;
 }
 
-.form-group input:focus {
+.form-group input:focus,
+.form-group select:focus {
     outline: none;
     border-color: var(--primary-color);
 }


### PR DESCRIPTION
## Summary
- Merge service length, privilege leave, and sick leave fields into one form row, keeping each input in its own form group
- Apply shared styling and focus behavior to both input and select elements in form groups

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd1b10388325a7e31db5bc8a542b