### PR TITLE
Add month range filter to admin leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,6 +392,11 @@
             <div class="admin-panel">
                 <div class="section">
                     <h2>Leave History</h2>
+                    <div class="history-filters" style="margin-bottom: 10px;">
+                        <input type="month" id="historyStartMonth">
+                        <input type="month" id="historyEndMonth">
+                        <button id="filterHistoryBtn" class="btn btn-primary">Filter</button>
+                    </div>
                     <div id="weeklyHistory"></div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add month inputs and filter button to admin leave history tab
- Allow admin leave history to filter by month range with 12-month limit
- Hook filter button and tab activation to filtered history loader

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b909564564832591e9eaa71a9f5624