### PR TITLE
Add PDF export for leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,10 @@
         <div id="check-history" class="tab-content">
             <section class="section">
                 <h2>🔍 My Vacation Requests</h2>
+                <div class="history-controls">
+                    <!-- Existing sort controls would appear here -->
+                    <button id="exportHistoryPdf" class="btn btn-secondary">Export to PDF</button>
+                </div>
                 <div class="table-container">
                     <table id="historyTable">
                         <thead>
@@ -544,6 +548,8 @@
         </div>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add "Export to PDF" button to the history tab and load jsPDF libraries
- Implement `exportHistoryPdf` to build a PDF of the current table contents
- Hook up export button to gather current filters and generate the PDF

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90958f26c832589734136963ea441