### PR TITLE
Add admin leave history sorting by employee name

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,6 +392,10 @@
             <div class="admin-panel">
                 <div class="section">
                     <h2>Leave History</h2>
+                    <select id="historySort">
+                        <option value="az">Employee A–Z</option>
+                        <option value="za">Employee Z–A</option>
+                    </select>
                     <div id="weeklyHistory"></div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1756,13 +1756,15 @@ async function loadLeaveHistory(employeeId) {
     }
 }
 
-async function loadAdminLeaveHistory() {
+async function loadAdminLeaveHistory(sortOrder = 'az') {
     const container = document.getElementById('weeklyHistory');
     if (!container) return;
     container.innerHTML = '';
     try {
         const apps = await room.collection('leave_application').getList({ status: 'Approved' });
-        apps.sort((a, b) => new Date(b.start_date) - new Date(a.start_date));
+        apps.sort((a, b) => sortOrder === 'za'
+            ? b.employee_name.localeCompare(a.employee_name)
+            : a.employee_name.localeCompare(b.employee_name));
 
         const groups = {};
         apps.forEach(app => {
@@ -1955,7 +1957,8 @@ function switchTab(tabName) {
         loadEmployeeSummary();
         loadLeaveApplications();
     } else if (tabName === 'admin-history') {
-        loadAdminLeaveHistory();
+        const sort = document.getElementById('historySort')?.value;
+        loadAdminLeaveHistory(sort);
     }
 }
 
@@ -2054,6 +2057,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const searchInput = document.getElementById('employeeSearch');
     if (searchInput) {
         searchInput.addEventListener('input', loadEmployeeSummary);
+    }
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+    const sortSelect = document.getElementById('historySort');
+    if (sortSelect) {
+        sortSelect.addEventListener('change', (e) => loadAdminLeaveHistory(e.target.value));
     }
 });
 


### PR DESCRIPTION
## Summary
- Add Employee A–Z/Z–A dropdown to admin leave history tab
- Allow loadAdminLeaveHistory to sort records by employee name based on selection
- Re-render history when sort order changes

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9095ac94c8325b422196f3ebc2860