### PR TITLE
Set default PL days from service length

### DIFF
--- a/script.js
+++ b/script.js
@@ -632,6 +632,9 @@ function setupCriticalFormHandlers() {
                 updatePrivilegeLeave('serviceLength', 'annualLeave');
             });
 
+            // Set default PL days based on the initial service length selection
+            updatePrivilegeLeave('serviceLength', 'annualLeave');
+
             if (debugImmediateSetup) {
                 console.log('✅ Service length change handler attached immediately');
             }


### PR DESCRIPTION
## Summary
- Ensure the Add New Employee form sets privilege leave days immediately based on service length

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9098af7888325aa12ebefff5711ba