### PR TITLE
Add filtering options for leave application queries

### DIFF
--- a/script.js
+++ b/script.js
@@ -1759,12 +1759,16 @@ async function loadLeaveHistory(employeeId) {
     }
 }
 
-async function loadAdminLeaveHistory(sortOrder = 'az') {
+async function loadAdminLeaveHistory(sortOrder = 'az', employeeName = '', startDate = '', endDate = '') {
     const container = document.getElementById('weeklyHistory');
     if (!container) return;
     container.innerHTML = '';
     try {
-        const apps = await room.collection('leave_application').getList({ status: 'Approved' });
+        const params = { status: 'Approved' };
+        if (employeeName) params.employee_name = employeeName;
+        if (startDate) params.start_date = startDate;
+        if (endDate) params.end_date = endDate;
+        const apps = await room.collection('leave_application').getList(params);
         apps.sort((a, b) => sortOrder === 'za'
             ? b.employee_name.localeCompare(a.employee_name)
             : a.employee_name.localeCompare(b.employee_name));
@@ -1961,7 +1965,10 @@ function switchTab(tabName) {
         loadLeaveApplications();
     } else if (tabName === 'admin-history') {
         const sort = document.getElementById('historySort')?.value;
-        loadAdminLeaveHistory(sort);
+        const employeeName = document.getElementById('historyEmployeeName')?.value || '';
+        const startDate = document.getElementById('historyStartDate')?.value || '';
+        const endDate = document.getElementById('historyEndDate')?.value || '';
+        loadAdminLeaveHistory(sort, employeeName, startDate, endDate);
     }
 }
 
@@ -2066,7 +2073,12 @@ document.addEventListener('DOMContentLoaded', function() {
 document.addEventListener('DOMContentLoaded', function() {
     const sortSelect = document.getElementById('historySort');
     if (sortSelect) {
-        sortSelect.addEventListener('change', (e) => loadAdminLeaveHistory(e.target.value));
+        sortSelect.addEventListener('change', (e) => {
+            const employeeName = document.getElementById('historyEmployeeName')?.value || '';
+            const startDate = document.getElementById('historyStartDate')?.value || '';
+            const endDate = document.getElementById('historyEndDate')?.value || '';
+            loadAdminLeaveHistory(e.target.value, employeeName, startDate, endDate);
+        });
     }
 });
 

--- a/server.py
+++ b/server.py
@@ -188,7 +188,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                     results = [dict(row) for row in cursor.fetchall()]
                     
                 elif collection == 'leave_application':
-                    # Get leave applications with optional employee and status filters
+                    # Get leave applications with optional filters
                     base_query = 'SELECT * FROM leave_applications'
                     conditions = []
                     params = []
@@ -198,6 +198,15 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                     if 'status' in query:
                         conditions.append('status = ?')
                         params.append(query['status'][0])
+                    if 'employee_name' in query:
+                        conditions.append('employee_name LIKE ?')
+                        params.append(f"%{query['employee_name'][0]}%")
+                    if 'start_date' in query:
+                        conditions.append('start_date >= ?')
+                        params.append(query['start_date'][0])
+                    if 'end_date' in query:
+                        conditions.append('end_date <= ?')
+                        params.append(query['end_date'][0])
                     if conditions:
                         base_query += ' WHERE ' + ' AND '.join(conditions)
                     base_query += ' ORDER BY created_at DESC'


### PR DESCRIPTION
## Summary
- Support filtering leave applications by employee name and date range
- Pass new filters from admin history UI when present

## Testing
- `python -m py_compile server.py services/*.py`
- `python server.py 8081` *(queried `/api/leave_application` with and without filters)*

------
https://chatgpt.com/codex/tasks/task_e_68b9100f7c9c832597dec18c5abd6aa7