### PR TITLE
Add search and month range filters to admin leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,9 +392,36 @@
             <div class="admin-panel">
                 <div class="section">
                     <h2>Leave History</h2>
-                    <select id="historySort">
-                        <option value="az">Employee A–Z</option>
-                        <option value="za">Employee Z–A</option>
+                    <input type="text" id="historySearch" placeholder="Search employee">
+                    <select id="historyStartMonth">
+                        <option value="">Start Month</option>
+                        <option value="1">January</option>
+                        <option value="2">February</option>
+                        <option value="3">March</option>
+                        <option value="4">April</option>
+                        <option value="5">May</option>
+                        <option value="6">June</option>
+                        <option value="7">July</option>
+                        <option value="8">August</option>
+                        <option value="9">September</option>
+                        <option value="10">October</option>
+                        <option value="11">November</option>
+                        <option value="12">December</option>
+                    </select>
+                    <select id="historyEndMonth">
+                        <option value="">End Month</option>
+                        <option value="1">January</option>
+                        <option value="2">February</option>
+                        <option value="3">March</option>
+                        <option value="4">April</option>
+                        <option value="5">May</option>
+                        <option value="6">June</option>
+                        <option value="7">July</option>
+                        <option value="8">August</option>
+                        <option value="9">September</option>
+                        <option value="10">October</option>
+                        <option value="11">November</option>
+                        <option value="12">December</option>
                     </select>
                     <div id="weeklyHistory"></div>
                 </div>


### PR DESCRIPTION
## Summary
- Allow admin leave history to be filtered by employee search and month range
- Filter approved applications by employee name and date range before grouping
- Add UI inputs and listeners to trigger filtered history loading

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9101160c083259815490ec6247c73