### PR TITLE
Add PDF export for admin leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,6 +396,7 @@
                         <option value="az">Employee A–Z</option>
                         <option value="za">Employee Z–A</option>
                     </select>
+                    <button type="button" id="exportHistoryPdf" class="btn btn-secondary">Export PDF</button>
                     <div id="weeklyHistory"></div>
                 </div>
             </div>
@@ -549,5 +550,6 @@
     </div>
 
     <script src="script.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.2/html2pdf.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add HTML button and html2pdf.js library for PDF export
- implement exportAdminLeaveHistoryPdf to generate file name and render history
- wire up export button and ensure week details expanded before capture

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b912f679dc8325a27a2608d6688364