### PR TITLE
Add search and month pickers to admin leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,37 +392,17 @@
             <div class="admin-panel">
                 <div class="section">
                     <h2>Leave History</h2>
-                    <input type="text" id="historySearch" placeholder="Search employee">
-                    <select id="historyStartMonth">
-                        <option value="">Start Month</option>
-                        <option value="1">January</option>
-                        <option value="2">February</option>
-                        <option value="3">March</option>
-                        <option value="4">April</option>
-                        <option value="5">May</option>
-                        <option value="6">June</option>
-                        <option value="7">July</option>
-                        <option value="8">August</option>
-                        <option value="9">September</option>
-                        <option value="10">October</option>
-                        <option value="11">November</option>
-                        <option value="12">December</option>
-                    </select>
-                    <select id="historyEndMonth">
-                        <option value="">End Month</option>
-                        <option value="1">January</option>
-                        <option value="2">February</option>
-                        <option value="3">March</option>
-                        <option value="4">April</option>
-                        <option value="5">May</option>
-                        <option value="6">June</option>
-                        <option value="7">July</option>
-                        <option value="8">August</option>
-                        <option value="9">September</option>
-                        <option value="10">October</option>
-                        <option value="11">November</option>
-                        <option value="12">December</option>
-                    </select>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <input id="historySearch" type="text" placeholder="Search employee…">
+                        </div>
+                        <div class="form-group">
+                            <input id="historyStartMonth" type="month">
+                        </div>
+                        <div class="form-group">
+                            <input id="historyEndMonth" type="month">
+                        </div>
+                    </div>
                     <div id="weeklyHistory"></div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1766,11 +1766,14 @@ async function loadAdminLeaveHistory(search = '', startMonth = '', endMonth = ''
     try {
         const year = new Date().getFullYear();
         const startDate = startMonth
-            ? new Date(year, parseInt(startMonth) - 1, 1)
+            ? new Date(`${startMonth}-01`)
             : new Date(year, 0, 1);
-        const endDate = endMonth
-            ? new Date(year, parseInt(endMonth), 0)
+        let endDate = endMonth
+            ? new Date(`${endMonth}-01`)
             : new Date(year, 11, 31);
+        if (endMonth) {
+            endDate = new Date(endDate.getFullYear(), endDate.getMonth() + 1, 0);
+        }
 
         const apps = await room.collection('leave_application').getList({ status: 'Approved' });
 


### PR DESCRIPTION
## Summary
- Replace admin history sorting dropdown with search input and month pickers
- Style new filters using existing form-row and form-group structure
- Update admin history loader to parse YYYY-MM month values

## Testing
- `python -m py_compile server.py services/*.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9158343548325a4f977b54b555e41