### PR TITLE
Ensure PL days auto-populate after employee form reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -1246,6 +1246,7 @@ async function handleEmployeeFormSubmit() {
         
         // Reset form
         form.reset();
+        updatePrivilegeLeave('serviceLength', 'annualLeave');
         
         // Reload employee table
         await loadEmployeeList();


### PR DESCRIPTION
## Summary
- Ensure employee form reset repopulates privilege leave based on default service length

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b914d3f4bc8325996b114c4ae16038