### PR TITLE
Add PDF export for admin leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,6 +402,9 @@
                         <div class="form-group">
                             <input id="historyEndMonth" type="month">
                         </div>
+                        <div class="form-group">
+                            <button id="historyExportBtn" type="button">Export PDF</button>
+                        </div>
                     </div>
                     <div id="weeklyHistory"></div>
                 </div>
@@ -555,6 +558,7 @@
         </div>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add export PDF button and PDF library inclusion in admin history tab
- implement PDF export of weekly history with date range and filename formatting
- wire up export button to trigger the new export function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b91c3686908325a76369e9f80ee2a4