### PR TITLE
Use Noto Sans as primary font

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="styles/layout.css">
     <link rel="stylesheet" href="styles/responsive.css">
     <link rel="stylesheet" href="styles.css">
-    <link href="https://fonts.googleapis.com/css2?family=Cal+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Entry Point Selection -->

--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,7 @@
 }
 
 body {
-    font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: 'Noto Sans', 'Segoe UI', sans-serif;
     background-color: var(--background);
     color: var(--text-primary);
     line-height: 1.6;


### PR DESCRIPTION
## Summary
- Adopt Noto Sans as the site's primary typeface.
- Remove unused Cal Sans import in `index.html`.
- Align global `font-family` rule to Noto Sans in `styles.css`.

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b922fbcb148325a2b7581e4e9dc3fa