### PR TITLE
Add warning button styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -344,6 +344,15 @@ header p {
     border-color: var(--primary-color);
 }
 
+.btn-warning {
+    background: var(--warning-color);
+    color: white;
+}
+
+.btn-warning:hover {
+    background: #c2410c;
+}
+
 .btn-danger {
     background: var(--error-color);
     color: white;
@@ -883,7 +892,7 @@ tr:hover {
 
 /* Touch-friendly enhancements */
 @media (hover: none) and (pointer: coarse) {
-    .btn-primary, .btn-secondary {
+    .btn-primary, .btn-secondary, .btn-warning {
         padding: 18px 30px;
         font-size: 1.1rem;
     }


### PR DESCRIPTION
## Summary
- add `.btn-warning` button style using `--warning-color`
- include `.btn-warning` in touch-friendly button sizing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b922feddc883258b0f61587831c955