### PR TITLE
Remove webfont and revert to basic CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="styles/layout.css">
     <link rel="stylesheet" href="styles/responsive.css">
     <link rel="stylesheet" href="styles.css">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Entry Point Selection -->

--- a/styles.css
+++ b/styles.css
@@ -1,20 +1,3 @@
-/* CSS Variables for consistent theming */
-:root {
-    --primary-color: #2563eb;
-    --primary-hover: #1d4ed8;
-    --secondary-color: #64748b;
-    --success-color: #16a34a;
-    --warning-color: #ea580c;
-    --error-color: #dc2626;
-    --background: #f8fafc;
-    --surface: #ffffff;
-    --text-primary: #1e293b;
-    --text-secondary: #64748b;
-    --border-color: #e2e8f0;
-    --border-radius: 8px;
-    --box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-}
-
 * {
     box-sizing: border-box;
     margin: 0;
@@ -22,9 +5,9 @@
 }
 
 body {
-    font-family: 'Noto Sans', 'Segoe UI', sans-serif;
-    background-color: var(--background);
-    color: var(--text-primary);
+    font-family: Arial, Helvetica, sans-serif;
+    background-color: #f8fafc;
+    color: #1e293b;
     line-height: 1.6;
 }
 
@@ -43,24 +26,24 @@ header {
 header h1 {
     font-size: 2.5rem;
     margin-bottom: 10px;
-    color: var(--primary-color);
+    color: #2563eb;
 }
 
 header p {
-    color: var(--text-secondary);
+    color: #64748b;
     font-size: 1.1rem;
 }
 
 .vacation-form {
-    background: var(--surface);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
     overflow: hidden;
 }
 
 .form-section {
     padding: 30px;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid #e2e8f0;
 }
 
 .form-section:last-child {
@@ -69,14 +52,13 @@ header p {
 
 .form-section h2 {
     margin-bottom: 20px;
-    color: var(--text-primary);
+    color: #1e293b;
     font-size: 1.3rem;
 }
 
 /* Date Inputs */
 .date-inputs {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
     gap: 20px;
     margin-bottom: 15px;
 }
@@ -89,20 +71,20 @@ header p {
 .date-group label {
     margin-bottom: 8px;
     font-weight: 500;
-    color: var(--text-primary);
+    color: #1e293b;
 }
 
 .date-group input[type="date"] {
     padding: 12px;
-    border: 2px solid var(--border-color);
-    border-radius: var(--border-radius);
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
     font-size: 1rem;
     transition: border-color 0.2s ease;
 }
 
 .date-group input[type="date"]:focus {
     outline: none;
-    border-color: var(--primary-color);
+    border-color: #2563eb;
 }
 
 /* Duration display */
@@ -110,19 +92,19 @@ header p {
     text-align: center;
     padding: 15px;
     background: #f1f5f9;
-    border-radius: var(--border-radius);
+    border-radius: 8px;
     margin-top: 15px;
 }
 
 #durationText {
     font-weight: 500;
-    color: var(--text-secondary);
+    color: #64748b;
 }
 
 /* Leave Type Checkboxes */
 .leave-types {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
     gap: 15px;
     margin-bottom: 20px;
 }
@@ -133,42 +115,42 @@ header p {
     gap: 10px;
     cursor: pointer;
     padding: 10px;
-    border-radius: var(--border-radius);
+    border-radius: 8px;
     transition: background-color 0.2s ease;
 }
 
 .option-label:hover {
-    background-color: var(--background);
+    background-color: #f8fafc;
 }
 .option-label input[type="radio"] {
     width: 18px;
     height: 18px;
-    accent-color: var(--primary-color);
+    accent-color: #2563eb;
     cursor: pointer;
 }
 
 .checkmark {
     font-weight: 500;
-    color: var(--text-primary);
+    color: #1e293b;
 }
 
 .option-label input[type="radio"]:checked + .checkmark {
-    color: var(--primary-color);
+    color: #2563eb;
     font-weight: 600;
 }
 
 /* Employee Selection */
 .employee-selection {
-    background: var(--surface);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
     padding: 30px;
     margin-bottom: 30px;
 }
 
 .employee-selection h2 {
     margin-bottom: 20px;
-    color: var(--text-primary);
+    color: #1e293b;
     font-size: 1.3rem;
 }
 
@@ -181,17 +163,17 @@ header p {
 #employeeSelect {
     width: 100%;
     padding: 12px;
-    border: 2px solid var(--border-color);
-    border-radius: var(--border-radius);
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
     font-size: 1rem;
-    background: var(--surface);
+    background: #ffffff;
     transition: border-color 0.2s ease;
     margin-bottom: 15px;
 }
 
 #employeeSelect:focus {
     outline: none;
-    border-color: var(--primary-color);
+    border-color: #2563eb;
 }
 
 .employee-search {
@@ -201,23 +183,23 @@ header p {
 #employeeSearch {
     width: 100%;
     padding: 10px;
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius);
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
     font-size: 0.9rem;
-    background: var(--background);
+    background: #f8fafc;
 }
 
 #employeeSearch:focus {
     outline: none;
-    border-color: var(--primary-color);
+    border-color: #2563eb;
 }
 
 /* Tab Navigation */
 .tab-navigation {
     display: flex;
-    background: var(--surface);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
     margin-bottom: 30px;
     overflow: hidden;
 }
@@ -225,19 +207,19 @@ header p {
 .tab-button {
     flex: 1;
     background: transparent;
-    color: var(--text-secondary);
+    color: #64748b;
     border-bottom: 3px solid transparent;
 }
 
 .tab-button:hover {
-    background: var(--background);
-    color: var(--text-primary);
+    background: #f8fafc;
+    color: #1e293b;
 }
 
 .tab-button.active {
-    background: var(--primary-color);
+    background: #2563eb;
     color: white;
-    border-bottom-color: var(--primary-hover);
+    border-bottom-color: #1d4ed8;
 }
 
 /* Tab Content */
@@ -257,15 +239,15 @@ header p {
 }
 
 .section {
-    background: var(--surface);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
     padding: 30px;
 }
 
 .section h2 {
     margin-bottom: 20px;
-    color: var(--text-primary);
+    color: #1e293b;
     font-size: 1.3rem;
 }
 
@@ -289,14 +271,14 @@ header p {
 .form-group label {
     margin-bottom: 8px;
     font-weight: 500;
-    color: var(--text-primary);
+    color: #1e293b;
 }
 
 .form-group input,
 .form-group select {
     padding: 12px;
-    border: 2px solid var(--border-color);
-    border-radius: var(--border-radius);
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
     font-size: 1rem;
     transition: border-color 0.2s ease;
 }
@@ -304,14 +286,14 @@ header p {
 .form-group input:focus,
 .form-group select:focus {
     outline: none;
-    border-color: var(--primary-color);
+    border-color: #2563eb;
 }
 
 /* Buttons */
 .btn {
     padding: 12px 24px;
     border: none;
-    border-radius: var(--border-radius);
+    border-radius: 8px;
     font-size: 1rem;
     font-weight: 500;
     cursor: pointer;
@@ -319,16 +301,16 @@ header p {
 }
 
 .btn-primary {
-    background: var(--primary-color);
+    background: #2563eb;
     color: white;
 }
 
 .btn-primary:hover {
-    background: var(--primary-hover);
+    background: #1d4ed8;
 }
 
 .btn-secondary {
-    background: var(--secondary-color);
+    background: #64748b;
     color: white;
 }
 
@@ -337,7 +319,7 @@ header p {
 }
 
 .btn-success {
-    background: var(--success-color);
+    background: #16a34a;
     color: white;
 }
 
@@ -346,7 +328,7 @@ header p {
 }
 
 .btn-danger {
-    background: var(--error-color);
+    background: #dc2626;
     color: white;
 }
 
@@ -355,7 +337,7 @@ header p {
 }
 
 .btn-warning {
-    background: var(--warning-color);
+    background: #ea580c;
     color: white;
 }
 
@@ -367,8 +349,8 @@ header p {
 .table-container {
     overflow-x: auto;
     min-width: 100%;
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
+    border-radius: 8px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
 }
 
 table {
@@ -382,21 +364,21 @@ table {
 th, td {
     padding: 12px 16px;
     text-align: left;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid #e2e8f0;
     min-width: 120px;
 }
 
 th {
-    background: var(--background);
+    background: #f8fafc;
     font-weight: 600;
-    color: var(--text-primary);
+    color: #1e293b;
     position: sticky;
     top: 0;
     z-index: 1;
 }
 
 tr:hover {
-    background: var(--background);
+    background: #f8fafc;
 }
 
 .action-buttons {
@@ -431,8 +413,8 @@ tr:hover {
 }
 
 .modal-content {
-    background: var(--surface);
-    border-radius: var(--border-radius);
+    background: #ffffff;
+    border-radius: 8px;
     max-width: 500px;
     width: 100%;
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
@@ -455,7 +437,7 @@ tr:hover {
     justify-content: space-between;
     align-items: center;
     padding: 20px 30px;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid #e2e8f0;
 }
 
 .close-btn {
@@ -463,7 +445,7 @@ tr:hover {
     border: none;
     font-size: 24px;
     cursor: pointer;
-    color: var(--text-secondary);
+    color: #64748b;
     padding: 0;
     width: 30px;
     height: 30px;
@@ -473,7 +455,7 @@ tr:hover {
 }
 
 .close-btn:hover {
-    color: var(--text-primary);
+    color: #1e293b;
 }
 
 .edit-employee-form {
@@ -527,8 +509,8 @@ tr:hover {
 .spinner {
     width: 50px;
     height: 50px;
-    border: 4px solid var(--border-color);
-    border-top: 4px solid var(--primary-color);
+    border: 4px solid #e2e8f0;
+    border-top: 4px solid #2563eb;
     border-radius: 50%;
     animation: spin 1s linear infinite;
     margin-bottom: 20px;
@@ -587,15 +569,15 @@ tr:hover {
     justify-content: space-between;
     align-items: flex-start;
     padding: 15px;
-    background: var(--surface);
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius);
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
     transition: all 0.2s ease;
 }
 
 .notification-item.unread {
     background: #eff6ff;
-    border-color: var(--primary-color);
+    border-color: #2563eb;
 }
 
 .notification-item.read {
@@ -612,7 +594,7 @@ tr:hover {
 }
 
 .unread-indicator {
-    color: var(--primary-color);
+    color: #2563eb;
     font-size: 1.2rem;
     margin-left: 10px;
 }
@@ -624,7 +606,7 @@ tr:hover {
 
 .notification-popup h3 {
     margin-bottom: 15px;
-    color: var(--primary-color);
+    color: #2563eb;
 }
 
 .notification-popup p {
@@ -637,9 +619,9 @@ tr:hover {
     max-width: 400px;
     margin: 80px auto;
     padding: 30px;
-    background: var(--surface);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
 }
 
 /* Entry Point Selection Styles */
@@ -647,20 +629,20 @@ tr:hover {
     max-width: 500px;
     margin: 80px auto;
     padding: 40px;
-    background: var(--surface);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
     text-align: center;
 }
 
 .entry-content h1 {
-    color: var(--primary-color);
+    color: #2563eb;
     margin-bottom: 10px;
     font-size: 2rem;
 }
 
 .entry-content p {
-    color: var(--text-secondary);
+    color: #64748b;
     margin-bottom: 30px;
     font-size: 1.1rem;
 }
@@ -679,12 +661,12 @@ tr:hover {
     align-items: center;
     margin-bottom: 30px;
     padding-bottom: 20px;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid #e2e8f0;
 }
 
 .login-header h2 {
     margin: 0;
-    color: var(--primary-color);
+    color: #2563eb;
     font-size: 1.5rem;
 }
 
@@ -707,8 +689,8 @@ tr:hover {
     width: 100%;
     padding: 10px 12px;
     margin-bottom: 15px;
-    border: 2px solid var(--border-color);
-    border-radius: var(--border-radius);
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
     font-size: 1rem;
 }
 
@@ -721,13 +703,13 @@ tr:hover {
     gap: 15px;
     margin-top: 15px;
     padding: 15px;
-    background: var(--background);
-    border-radius: var(--border-radius);
+    background: #f8fafc;
+    border-radius: 8px;
 }
 
 #welcomeName {
     font-weight: 500;
-    color: var(--text-primary);
+    color: #1e293b;
     font-size: 1.1rem;
 }
 
@@ -747,9 +729,8 @@ tr:hover {
     header h1 {
         font-size: 2rem;
     }
-    
     .date-inputs {
-        grid-template-columns: 1fr;
+        flex-direction: column;
         gap: 15px;
     }
     
@@ -827,7 +808,7 @@ tr:hover {
     align-items: center;
     gap: 5px;
     font-size: 0.9rem;
-    color: var(--text-secondary);
+    color: #64748b;
     cursor: pointer;
 }
 
@@ -837,14 +818,14 @@ tr:hover {
 }
 
 .radio-label:hover {
-    color: var(--text-primary);
+    color: #1e293b;
 }
 
 /* Reason note */
 .reason-note {
     margin-top: 10px;
     font-size: 0.9rem;
-    color: var(--text-secondary);
+    color: #64748b;
     font-style: italic;
 }
 
@@ -868,7 +849,7 @@ tr:hover {
     padding: 20px;
     background: linear-gradient(135deg, #f0f9ff, #e0f2fe);
     border: 2px solid #0ea5e9;
-    border-radius: var(--border-radius);
+    border-radius: 8px;
     box-shadow: 0 2px 8px rgba(14, 165, 233, 0.1);
     /* @tweakable animation for balance updates */
     transition: all 0.3s ease;
@@ -876,7 +857,7 @@ tr:hover {
 
 .leave-balance-display h3 {
     margin: 0 0 15px 0;
-    color: var(--primary-color);
+    color: #2563eb;
     font-size: 1.1rem;
     font-weight: 600;
 }
@@ -893,8 +874,8 @@ tr:hover {
     justify-content: space-between;
     align-items: center;
     padding: 12px 16px;
-    background: var(--surface);
-    border-radius: var(--border-radius);
+    background: #ffffff;
+    border-radius: 8px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     transition: transform 0.2s ease;
 }
@@ -913,21 +894,21 @@ tr:hover {
 
 .balance-label {
     font-weight: 500;
-    color: var(--text-primary);
+    color: #1e293b;
     font-size: 0.95rem;
 }
 
 .balance-value {
     font-weight: 600;
     font-size: 1.1rem;
-    color: var(--primary-color);
+    color: #2563eb;
     /* @tweakable balance value transition for smooth updates */
     transition: all 0.5s ease;
 }
 
 .balance-note {
     display: block;
-    color: var(--text-secondary);
+    color: #64748b;
     font-style: italic;
     text-align: center;
     margin-top: 10px;
@@ -965,7 +946,7 @@ tr:hover {
     margin-top: 10px;
     text-align: center;
     padding-top: 10px;
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid #e2e8f0;
 }
 
 /* @tweakable styling for balance status indicators in admin view */
@@ -997,5 +978,5 @@ tr:hover {
 }
 
 .remaining-alert {
-    color: var(--error-color); /* #dc2626 */
+    color: #dc2626; /* #dc2626 */
 }


### PR DESCRIPTION
## Summary
- Drop Google Fonts import from index.html
- Revert styles.css to system fonts and explicit colors; remove CSS variables and grid layouts

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba47e032048325b54304430d7e6743