### PR TITLE
Initialize entry buttons after DOM ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@
             <h1>🏢 Employee Leave Management System</h1>
             <p>Please select your login type</p>
             <div class="entry-buttons">
-                <button id="employeeEntryBtn" class="entry-btn employee-btn" onclick="showEmployeeLogin()">
+                <button id="employeeEntryBtn" class="entry-btn employee-btn" type="button">
                     👤 Employee Login
                 </button>
-                <button id="adminEntryBtn" class="entry-btn admin-btn" onclick="showAdminLogin()">
+                <button id="adminEntryBtn" class="entry-btn admin-btn" type="button">
                     🔐 Administrator Login
                 </button>
             </div>

--- a/script.js
+++ b/script.js
@@ -782,8 +782,6 @@ function initEntryButtons() {
     }
 }
 
-initEntryButtons();
-
 function showEmployeeLogin() {
     /* @tweakable whether to log navigation to employee login */
     const logNavigation = true;


### PR DESCRIPTION
## Summary
- remove inline login handlers and add `type="button"` attributes to entry buttons
- call `initEntryButtons` only after `DOMContentLoaded` to bind click events
- retain global exposure of login helper functions

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba55d1609483259753c96f98daf82e