### PR TITLE
Simplify admin leave history with fiscal year table

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,37 +393,19 @@
                 <div class="section">
                     <h2>Leave History</h2>
                     <input type="text" id="historySearch" placeholder="Search employee">
-                    <select id="historyStartMonth">
-                        <option value="">Start Month</option>
-                        <option value="1">January</option>
-                        <option value="2">February</option>
-                        <option value="3">March</option>
-                        <option value="4">April</option>
-                        <option value="5">May</option>
-                        <option value="6">June</option>
-                        <option value="7">July</option>
-                        <option value="8">August</option>
-                        <option value="9">September</option>
-                        <option value="10">October</option>
-                        <option value="11">November</option>
-                        <option value="12">December</option>
-                    </select>
-                    <select id="historyEndMonth">
-                        <option value="">End Month</option>
-                        <option value="1">January</option>
-                        <option value="2">February</option>
-                        <option value="3">March</option>
-                        <option value="4">April</option>
-                        <option value="5">May</option>
-                        <option value="6">June</option>
-                        <option value="7">July</option>
-                        <option value="8">August</option>
-                        <option value="9">September</option>
-                        <option value="10">October</option>
-                        <option value="11">November</option>
-                        <option value="12">December</option>
-                    </select>
-                    <div id="weeklyHistory"></div>
+                    <div class="table-container">
+                        <table id="historyTable">
+                            <thead>
+                                <tr>
+                                    <th>Employee</th>
+                                    <th>Leave Type</th>
+                                    <th>Dates</th>
+                                    <th>Total Days</th>
+                                </tr>
+                            </thead>
+                            <tbody id="historyTableBody"></tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace month filters and weekly grouping with a simple history table in the Admin Leave History tab.
- Load admin leave history for the current fiscal year only and populate the new table.
- Export history PDF directly from the history table.

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb8131998c8325b82d6a953f5ec7f8