### PR TITLE
Show only approved leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
         <!-- Check Status/History Tab -->
         <div id="check-history" class="tab-content">
             <section class="section">
-                <h2>🔍 My Vacation Requests</h2>
+                <h2>🔍 My Approved Vacation Requests</h2>
                 <div class="table-container">
                     <table id="historyTable">
                         <thead>

--- a/script.js
+++ b/script.js
@@ -1733,9 +1733,13 @@ async function updateApplicationStatus(id, newStatus) {
 
 async function loadLeaveHistory(employeeId) {
     try {
+        // Fetch only approved leave applications for this employee
         const apps = await room
             .collection('leave_application')
-            .makeRequest('GET', `?employee_id=${encodeURIComponent(employeeId)}`);
+            .makeRequest(
+                'GET',
+                `?employee_id=${encodeURIComponent(employeeId)}&status=Approved`
+            );
 
         const tbody = document.getElementById('historyTableBody');
         tbody.innerHTML = '';


### PR DESCRIPTION
## Summary
- Fetch only approved leave applications in `loadLeaveHistory`.
- Clarify UI that history tab displays approved vacation requests.

## Testing
- `npm test` *(fails: enoent package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb955df90c83258c1e1ccee156cac6