### PR TITLE
Handle startup failures in DOMContentLoaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,11 @@
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Cal+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
-<body>
-    <!-- Entry Point Selection -->
+    <body>
+        <div id="loadError" style="display:none; background-color:#fee2e2; color:#b91c1c; text-align:center; padding:10px;">
+            Application failed to load.
+        </div>
+        <!-- Entry Point Selection -->
     <div id="entryContainer" class="entry-container">
         <div class="entry-content">
             <h1>🏢 Employee Leave Management System</h1>

--- a/script.js
+++ b/script.js
@@ -373,8 +373,9 @@ const SERVICE_LENGTH_MAP = {
 
 // Handle login and app initialization
 document.addEventListener('DOMContentLoaded', function() {
-    /* @tweakable whether to show debug messages during login flow initialization */
-    const debugLoginFlow = true;
+    try {
+        /* @tweakable whether to show debug messages during login flow initialization */
+        const debugLoginFlow = true;
     
     /* @tweakable whether to validate app container visibility on page load */
     const validateInitialVisibility = true;
@@ -573,8 +574,15 @@ document.addEventListener('DOMContentLoaded', function() {
         setupHandlersWithRetry();
     }, loginHandlerDelay);
     
-    if (debugLoginFlow) {
-        console.log('✅ Login flow initialization completed');
+        if (debugLoginFlow) {
+            console.log('✅ Login flow initialization completed');
+        }
+    } catch (error) {
+        console.error('Application failed to load:', error);
+        const errorBanner = document.getElementById('loadError');
+        if (errorBanner) {
+            errorBanner.style.display = 'block';
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- add top-level error banner to surface startup failures to users
- guard DOMContentLoaded initialization with try/catch and log load failures

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT no package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9da8e6888325bfcefd55f01e4a0c