### PR TITLE
Serve JavaScript with explicit UTF-8 content type

### DIFF
--- a/server.py
+++ b/server.py
@@ -120,6 +120,13 @@ def format_leave_request_email(
     )
 
 class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
+    def guess_type(self, path):
+        """Ensure JavaScript files are served with UTF-8 charset"""
+        base, ext = os.path.splitext(path)
+        if ext == '.js':
+            return 'application/javascript; charset=UTF-8'
+        return super().guess_type(path)
+
     def send_cors_headers(self):
         """Add CORS headers to the response"""
         self.send_header('Access-Control-Allow-Origin', '*')


### PR DESCRIPTION
## Summary
- ensure JS assets are served with `application/javascript; charset=UTF-8`
- override handler to provide explicit MIME type for `.js`

## Testing
- `python -m py_compile server.py`
- `curl -I http://localhost:8001/script.js`
- `curl http://localhost:8001/script.js | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_68bb9da64848832593427b9b83bcb03b