### PR TITLE
Normalize date handling for leave duration

### DIFF
--- a/script.js
+++ b/script.js
@@ -1480,8 +1480,11 @@ async function submitLeaveApplication(event) {
 function calculateTotalDays(startDate, endDate, startDayType, endDayType) {
     if (!startDate || !endDate) return 0;
 
-    const start = new Date(startDate);
-    const end = new Date(endDate);
+    // Normalize dates to local midnight to avoid timezone issues
+    const start = new Date(startDate + 'T00:00');
+    const end = new Date(endDate + 'T00:00');
+    start.setHours(0, 0, 0, 0);
+    end.setHours(0, 0, 0, 0);
     if (end < start) return 0;
 
     const startType = startDayType || document.querySelector('input[name="startDayType"]:checked')?.value || 'full';
@@ -1489,6 +1492,7 @@ function calculateTotalDays(startDate, endDate, startDayType, endDayType) {
 
     let total = 0;
     const current = new Date(start);
+    current.setHours(0, 0, 0, 0);
     while (current <= end) {
         const iso = current.toISOString().split('T')[0];
         const day = current.getDay();
@@ -1503,6 +1507,7 @@ function calculateTotalDays(startDate, endDate, startDayType, endDayType) {
             }
         }
         current.setDate(current.getDate() + 1);
+        current.setHours(0, 0, 0, 0);
     }
 
     return total;


### PR DESCRIPTION
## Summary
- Normalize start and end dates to local midnight before calculating duration
- Re-normalize loop iteration date each day to include both start and end days

## Testing
- `node - <<'NODE'` manual test of `calculateTotalDays` for 2025-09-08..2025-09-12 returns 5
- `npm test` *(fails: missing package.json)*
- `pytest` *(no tests collected)*


------
https://chatgpt.com/codex/tasks/task_e_68bba2815cb08325a0b9333c0656e635