### PR TITLE
Add status filter to admin leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,12 @@
                     <input type="text" id="historySearch" placeholder="Search employee">
                     <input type="date" id="historyStart" title="Start date">
                     <input type="date" id="historyEnd" title="End date">
+                    <select id="historyStatus">
+                        <option value="All">All Statuses</option>
+                        <option value="Pending">Pending</option>
+                        <option value="Approved">Approved</option>
+                        <option value="Rejected">Rejected</option>
+                    </select>
                     <div class="table-container">
                         <table id="historyTable">
                             <thead>
@@ -403,6 +409,7 @@
                                     <th>Leave Type</th>
                                     <th>Dates</th>
                                     <th>Total Days</th>
+                                    <th>Status</th>
                                 </tr>
                             </thead>
                             <tbody id="historyTableBody"></tbody>

--- a/script.js
+++ b/script.js
@@ -1766,7 +1766,10 @@ async function loadAdminLeaveHistory(search = '') {
     if (!tbody) return;
     tbody.innerHTML = '';
     try {
-        const apps = await room.collection('leave_application').getList({ status: 'Approved' });
+        const status = document.getElementById('historyStatus')?.value || 'All';
+        const params = {};
+        if (status !== 'All') params.status = status;
+        const apps = await room.collection('leave_application').getList(params);
         if (requestId !== adminHistoryRequestId) return;
 
         const startInput = document.getElementById('historyStart')?.value;
@@ -1786,13 +1789,13 @@ async function loadAdminLeaveHistory(search = '') {
 
         filtered.forEach(app => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${app.employee_name}</td><td>${app.leave_type}</td><td>${app.start_date} - ${app.end_date}</td><td>${app.total_days ?? calculateTotalDays(app.start_date, app.end_date, app.start_day_type, app.end_day_type)}</td>`;
+            tr.innerHTML = `<td>${app.employee_name}</td><td>${app.leave_type}</td><td>${app.start_date} - ${app.end_date}</td><td>${app.total_days ?? calculateTotalDays(app.start_date, app.end_date, app.start_day_type, app.end_day_type)}</td><td>${app.status}</td>`;
             tbody.appendChild(tr);
         });
 
         if (filtered.length === 0) {
             const tr = document.createElement('tr');
-            tr.innerHTML = '<td colspan="4">No leave applications found</td>';
+            tr.innerHTML = '<td colspan="5">No leave applications found</td>';
             tbody.appendChild(tr);
         }
     } catch (error) {
@@ -2086,6 +2089,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const exportBtn = document.getElementById('historyExportBtn');
     const startInput = document.getElementById('historyStart');
     const endInput = document.getElementById('historyEnd');
+    const statusSelect = document.getElementById('historyStatus');
 
     let reloadTimeout;
     const reload = () => {
@@ -2099,6 +2103,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (searchInput) searchInput.addEventListener('input', reload);
     if (startInput) startInput.addEventListener('change', reload);
     if (endInput) endInput.addEventListener('change', reload);
+    if (statusSelect) statusSelect.addEventListener('change', reload);
     if (exportBtn) exportBtn.addEventListener('click', exportAdminHistoryPdf);
 });
 


### PR DESCRIPTION
## Summary
- Allow admins to fetch leave applications by optional status and show each request's current status.
- Add status dropdown and status column to the Leave History table.

## Testing
- `npm test` (fails: ENOENT, no package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bba78b71c48325b2f20c6756569f00