### PR TITLE
Use distinct IDs for history tables to avoid conflicts

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
             <section class="section">
                 <h2>🔍 My Approved Vacation Requests</h2>
                 <div class="table-container">
-                    <table id="historyTable">
+                    <table id="employeeHistoryTable">
                         <thead>
                             <tr>
                                 <th>Application ID</th>
@@ -259,7 +259,7 @@
                                 <th>Status</th>
                             </tr>
                         </thead>
-                        <tbody id="historyTableBody">
+                        <tbody id="employeeHistoryTableBody">
                             <!-- History rows will be populated here -->
                         </tbody>
                     </table>
@@ -396,7 +396,7 @@
                     <input type="date" id="historyStart" title="Start date">
                     <input type="date" id="historyEnd" title="End date">
                     <div class="table-container">
-                        <table id="historyTable">
+                        <table id="adminHistoryTable">
                             <thead>
                                 <tr>
                                     <th>Employee</th>
@@ -405,7 +405,7 @@
                                     <th>Total Days</th>
                                 </tr>
                             </thead>
-                            <tbody id="historyTableBody"></tbody>
+                            <tbody id="adminHistoryTableBody"></tbody>
                         </table>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -1734,7 +1734,7 @@ async function loadLeaveHistory(employeeId) {
                 `?employee_id=${encodeURIComponent(employeeId)}&status=Approved`
             );
 
-        const tbody = document.getElementById('historyTableBody');
+        const tbody = document.getElementById('employeeHistoryTableBody');
         tbody.innerHTML = '';
 
         apps.forEach(app => {
@@ -1762,7 +1762,7 @@ async function loadLeaveHistory(employeeId) {
 
 async function loadAdminLeaveHistory(search = '') {
     const requestId = ++adminHistoryRequestId;
-    const tbody = document.getElementById('historyTableBody');
+    const tbody = document.getElementById('adminHistoryTableBody');
     if (!tbody) return;
     tbody.innerHTML = '';
     try {
@@ -1801,7 +1801,7 @@ async function loadAdminLeaveHistory(search = '') {
 }
 
 async function exportAdminHistoryPdf() {
-    const container = document.getElementById('historyTable');
+    const container = document.getElementById('adminHistoryTable');
     if (!container) return;
 
     const dateCells = container.querySelectorAll('tbody tr td:nth-child(3)');


### PR DESCRIPTION
## Summary
- Give employee and admin leave history tables unique IDs to prevent DOM collisions.
- Update script logic to reference the new employeeHistoryTableBody and adminHistoryTableBody IDs.

## Testing
- `node --check script.js`
- `python -m py_compile server.py services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bba84d6150832593ebe4e56e8d712b