### PR TITLE
Send ICS invite only to manager on leave approval

### DIFF
--- a/server.py
+++ b/server.py
@@ -653,7 +653,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                             SMTP_PORT,
                                             SMTP_USERNAME,
                                             SMTP_PASSWORD,
-                                            ics_content=ics_content,
+                                            ics_content=None,
                                         )
                                     except Exception as email_err:
                                         print(f"⚠️ Failed to notify employee {employee_id}: {email_err}")


### PR DESCRIPTION
## Summary
- Only attach calendar ICS invite to manager's email when approving leave
- Notify employee of approval/rejection without calendar attachment

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bba8a798ec8325b4013fa4af7df5a3