### PR TITLE
Remove manual date filters from admin leave history

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,8 +393,6 @@
                 <div class="section">
                     <h2>Leave History</h2>
                     <input type="text" id="historySearch" placeholder="Search employee">
-                    <input type="date" id="historyStart" title="Start date">
-                    <input type="date" id="historyEnd" title="End date">
                     <div class="table-container">
                         <table id="adminHistoryTable">
                             <thead>


### PR DESCRIPTION
## Summary
- Remove date range inputs from admin leave history view
- Filter admin leave history to current fiscal year automatically
- Drop unused DOM lookups and listeners for removed fields

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbad7b4ed08325840dae17dc2dd5a2