### PR TITLE
Add calendar method and organizer to ICS events

### DIFF
--- a/server.py
+++ b/server.py
@@ -618,8 +618,14 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                     "HR Department\\n"
                                 )
 
+                                manager_email = (
+                                    app_info['manager_email']
+                                    if 'manager_email' in app_info.keys() and app_info['manager_email']
+                                    else MANAGER_EMAIL or ADMIN_EMAIL
+                                )
+
                                 ics_content = None
-                                if new_status == 'Approved':
+                                if new_status == 'Approved' and manager_email:
                                     ics_content = generate_ics_content(
                                         start_date,
                                         end_date,
@@ -628,13 +634,9 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                             f"Approved leave from {start_date} to {end_date} "
                                             f"({total_days} days)"
                                         ),
+                                        organizer=SMTP_USERNAME,
+                                        attendee=manager_email,
                                     )
-
-                                manager_email = (
-                                    app_info['manager_email']
-                                    if 'manager_email' in app_info.keys() and app_info['manager_email']
-                                    else MANAGER_EMAIL or ADMIN_EMAIL
-                                )
                                 if manager_email:
                                     try:
                                         send_notification_email(

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -23,6 +23,8 @@ def generate_ics_content(
     end_date: str,
     summary: str,
     description: str | None = None,
+    organizer: str | None = None,
+    attendee: str | None = None,
 ) -> str:
     """Create a basic ICS calendar event.
 
@@ -36,6 +38,10 @@ def generate_ics_content(
         Event title shown on the calendar entry.
     description:
         Optional description to include with the event.
+    organizer:
+        Optional email address to populate the ``ORGANIZER`` field.
+    attendee:
+        Optional email address to populate the ``ATTENDEE`` field.
     """
 
     start_dt = datetime.fromisoformat(start_date)
@@ -46,6 +52,7 @@ def generate_ics_content(
     lines = [
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
+        "METHOD:REQUEST",
         "PRODID:-//Leave Management System//EN",
         "BEGIN:VEVENT",
         f"UID:{uid}",
@@ -57,6 +64,10 @@ def generate_ics_content(
 
     if description:
         lines.append(f"DESCRIPTION:{description}")
+    if organizer:
+        lines.append(f"ORGANIZER:mailto:{organizer}")
+    if attendee:
+        lines.append(f"ATTENDEE:mailto:{attendee}")
 
     lines.extend(["END:VEVENT", "END:VCALENDAR"])
 
@@ -109,6 +120,7 @@ def send_notification_email(
             maintype="text",
             subtype="calendar",
             filename="event.ics",
+            params={"method": "REQUEST"},
         )
 
     try:


### PR DESCRIPTION
## Summary
- insert `METHOD:REQUEST` into generated iCalendar content
- allow specifying organizer and attendee in ICS generator and pass manager email
- mark calendar attachments with `method=REQUEST` for better client compatibility

## Testing
- `python -m py_compile services/email_service.py server.py`
- `pytest -q`
- `pip install icalendar` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb2329e1c83258461c9da596eec6a