### PR TITLE
Update manager approval email with direct wording and ICS note

### DIFF
--- a/server.py
+++ b/server.py
@@ -595,14 +595,16 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                 employee_name = app_info['employee_name']
                                 status_word = 'approved' if new_status == 'Approved' else 'rejected'
 
-                                manager_subject = f"Leave application {status_word}: {employee_name}"
+                                manager_subject = f"You approved leave for {employee_name}"
                                 manager_body = (
-                                    f"Leave request for {employee_name} (Application ID: {app_id}) has been {status_word}.\\n\\n"
-                                    "Request Details:\\n"
+                                    f"You have approved the leave for {employee_name} (Application ID: {app_id}).\\n\\n"
+                                    f"Leave details:\\n"
                                     f"- Leave Type: {leave_type}\\n"
                                     f"- Start Date: {start_date}\\n"
                                     f"- End Date: {end_date}\\n"
-                                    f"- Total Days: {total_days}\\n"
+                                    f"- Total Days: {total_days}\\n\\n"
+                                    "Add this leave to your calendar using the attached event.\\n\\n"
+                                    "Best regards,\\nHR Department"
                                 )
                                 employee_subject = f"Your leave application has been {status_word}"
                                 employee_body = (


### PR DESCRIPTION
## Summary
- Refine manager email when approving leave to address approver directly and encourage adding event to calendar

## Testing
- `python -m py_compile server.py services/email_service.py`
- `PYTHONPATH=/workspace/Leave-Management-System python /tmp/sendtest.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbb237bd408325b815d082232c89e3