### PR TITLE
Mark calendar invites as meeting requests

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -47,6 +47,7 @@ def generate_ics_content(
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
         "PRODID:-//Leave Management System//EN",
+        "METHOD:REQUEST",
         "BEGIN:VEVENT",
         f"UID:{uid}",
         f"DTSTAMP:{dtstamp}",
@@ -109,6 +110,7 @@ def send_notification_email(
             maintype="text",
             subtype="calendar",
             filename="event.ics",
+            params={"method": "REQUEST"},
         )
 
     try:


### PR DESCRIPTION
## Summary
- Tag generated ICS files with `METHOD:REQUEST`
- Attach ICS files with `method=REQUEST` parameter for calendaring

## Testing
- `pytest`
- `python -m py_compile services/email_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bccf9f1e9883259ed5e73feb0b3c64