### PR TITLE
Load admin email from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ADMIN_EMAIL=admin@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.pyo
 *.pyd
 
+# Local environment variables
+.env
+

--- a/README.md
+++ b/README.md
@@ -45,3 +45,18 @@ A comprehensive web-based leave management system designed for small to medium o
    SMTP_PASSWORD = "your-app-password"     # Your Gmail App Password
    ```
 
+#### Administrator Email
+
+The server requires an email address for the administrator so notifications can
+be delivered when employees submit leave requests. Set this via an
+`ADMIN_EMAIL` environment variable. The application will read variables from a
+local `.env` file if present:
+
+```bash
+# .env
+ADMIN_EMAIL=admin@example.com
+```
+
+Make sure to provide a real address in production so alerts reach the
+appropriate person.
+

--- a/server.py
+++ b/server.py
@@ -35,11 +35,27 @@ from services.email_service import (
     SMTP_PASSWORD,
 )
 
+# Load environment variables from a .env file if present
+def _load_env(path: str = ".env") -> None:
+    """Populate ``os.environ`` from a ``.env`` file if it exists."""
+    if os.path.exists(path):
+        with open(path) as env_file:
+            for raw_line in env_file:
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, _, value = line.partition("=")
+                os.environ.setdefault(key.strip(), value.strip())
+
+_load_env()
+
 # Default sick leave allocation
 DEFAULT_SICK_LEAVE = 5
 
 # @tweakable server configuration
-ADMIN_EMAIL = "mgllanos@gmail.com"
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL")
+if not ADMIN_EMAIL:
+    raise RuntimeError("ADMIN_EMAIL environment variable is required")
 ADMIN_USERNAME = "admin"
 ADMIN_PASSWORD = "admin123"
 


### PR DESCRIPTION
## Summary
- load .env file and require `ADMIN_EMAIL`
- document `ADMIN_EMAIL` setup in README
- ignore `.env` and provide `.env.example`

## Testing
- `python -m py_compile server.py`
- `python - <<'PY'
import os
os.environ['ADMIN_EMAIL']='admin@example.com'
import server
print('Loaded', server.ADMIN_EMAIL)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bccfa479a083259aa2905a79dbbfd1