### PR TITLE
Add default admin email configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ADMIN_EMAIL=mgllanos@gmail.com

--- a/server.py
+++ b/server.py
@@ -53,7 +53,7 @@ _load_env()
 DEFAULT_SICK_LEAVE = 5
 
 # @tweakable server configuration
-ADMIN_EMAIL = os.getenv("ADMIN_EMAIL")
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "mgllanos@gmail.com")
 if not ADMIN_EMAIL:
     raise RuntimeError("ADMIN_EMAIL environment variable is required")
 ADMIN_USERNAME = "admin"


### PR DESCRIPTION
## Summary
- default admin email `mgllanos@gmail.com` loaded from environment with fallback
- add `.env` with default admin email

## Testing
- `python -m py_compile server.py`
- `python -m py_compile services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd4a05cc0832593b199192b637707