### PR TITLE
Generate calendar invites on leave approval

### DIFF
--- a/server.py
+++ b/server.py
@@ -544,14 +544,16 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
 
                                 ics_content = None
                                 if new_status == 'Approved':
+                                    summary = f"Leave for {employee_name}"
+                                    description = (
+                                        f"Approved leave from {start_date} to {end_date} "
+                                        f"({total_days} days)"
+                                    )
                                     ics_content = generate_ics_content(
                                         start_date,
                                         end_date,
-                                        summary=f"Leave for {employee_name}",
-                                        description=(
-                                            f"Approved leave from {start_date} to {end_date} "
-                                            f"({total_days} days)"
-                                        ),
+                                        summary,
+                                        description,
                                     )
 
                                 try:
@@ -563,7 +565,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                         SMTP_PORT,
                                         SMTP_USERNAME,
                                         SMTP_PASSWORD,
-                                        ics_content=ics_content,
+                                        ics_content,
                                     )
                                 except Exception as email_err:
                                     print(f"⚠️ Failed to notify manager for {record_id}: {email_err}")
@@ -578,7 +580,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                             SMTP_PORT,
                                             SMTP_USERNAME,
                                             SMTP_PASSWORD,
-                                            ics_content=ics_content,
+                                            ics_content,
                                         )
                                     except Exception as email_err:
                                         print(f"⚠️ Failed to notify employee {employee_id}: {email_err}")


### PR DESCRIPTION
## Summary
- build ICS event on leave approval and attach to notification emails
- ensure SMTP configuration uses environment variables for credentials

## Testing
- `python -m py_compile server.py services/*.py`
- `python - <<'PY'
from services.email_service import generate_ics_content
print(generate_ics_content('2023-10-05','2023-10-07','Test Event','Some description'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bcdf33792c8325b2a421e7e857bd3f