### PR TITLE
Notify admin with ICS on leave approval

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -16,6 +16,7 @@ SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.gmail.com")
 SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
 SMTP_USERNAME = os.getenv("SMTP_USERNAME", "qtaskvacation@gmail.com")
 SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "bicg llyb myff kigu")
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@example.com")
 
 
 def generate_ics_content(

--- a/services/leave_service.py
+++ b/services/leave_service.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 from typing import Optional
 
 from .database_service import get_db_connection
-from .email_service import send_notification_email, generate_ics_content
+from .email_service import (
+    ADMIN_EMAIL,
+    generate_ics_content,
+    send_notification_email,
+)
 
 
 def approve_leave_request(application_id: str) -> bool:
-    """Finalize approval for a leave request and notify the employee.
+    """Finalize approval for a leave request and notify the employee and admin.
 
     Parameters
     ----------
@@ -71,6 +75,10 @@ def approve_leave_request(application_id: str) -> bool:
     except Exception:
         ics = None
 
-    send_notification_email(employee_email, subject, body, ics_content=ics)
+    # Notify the employee without calendar attachment
+    send_notification_email(employee_email, subject, body, ics_content=None)
+
+    # Notify the admin with the ICS attachment if available
+    send_notification_email(ADMIN_EMAIL, subject, body, ics_content=ics)
     return True
 


### PR DESCRIPTION
## Summary
- Define configurable `ADMIN_EMAIL` constant for notifications
- Send leave approval without calendar attachment to employee and with ICS to admin

## Testing
- `python -m py_compile services/email_service.py services/leave_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bceb56f5988325bd32fc29afae3bc6