### PR TITLE
Send calendar invites only to admins

### DIFF
--- a/server.py
+++ b/server.py
@@ -565,7 +565,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                         SMTP_PORT,
                                         SMTP_USERNAME,
                                         SMTP_PASSWORD,
-                                        ics_content,
+                                        ics_content=ics_content,
                                     )
                                 except Exception as email_err:
                                     print(f"⚠️ Failed to notify manager for {record_id}: {email_err}")
@@ -580,7 +580,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                             SMTP_PORT,
                                             SMTP_USERNAME,
                                             SMTP_PASSWORD,
-                                            ics_content,
+                                            ics_content=None,
                                         )
                                     except Exception as email_err:
                                         print(f"⚠️ Failed to notify employee {employee_id}: {email_err}")


### PR DESCRIPTION
## Summary
- Only send ICS attachments to the admin when updating leave applications
- Ensure employee notifications are sent without calendar invites

## Testing
- `python -m py_compile server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bceb5ec1cc8325a6b55067de5a12ab