### PR TITLE
Specify calendar attachment maintype in email service

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -89,6 +89,7 @@ def send_notification_email(
     if ics_content:
         msg.add_attachment(
             ics_content,
+            maintype="text",
             subtype="calendar",
             filename="event.ics",
         )


### PR DESCRIPTION
## Summary
- specify text/calendar MIME type by adding maintype="text" in calendar attachment

## Testing
- `python -m py_compile services/email_service.py && echo 'py_compile success'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bceb60b0e48325bb2bf29231720673