### PR TITLE
Remove env loading and hard-code admin email

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,8 @@ A comprehensive web-based leave management system designed for small to medium o
 
 #### Administrator Email
 
-The server requires an email address for the administrator so notifications can
-be delivered when employees submit leave requests. Set this via an
-`ADMIN_EMAIL` environment variable. The application will read variables from a
-local `.env` file if present:
-
-```bash
-# .env
-ADMIN_EMAIL=admin@example.com
-```
-
-Make sure to provide a real address in production so alerts reach the
-appropriate person.
+The server uses a built-in administrator email address so notifications can be
+delivered when employees submit leave requests. The default address is defined
+directly in `server.py` and no `.env` entry or environment variable is
+required. To customize it, edit the `ADMIN_EMAIL` constant in `server.py`.
 

--- a/server.py
+++ b/server.py
@@ -35,27 +35,11 @@ from services.email_service import (
     SMTP_PASSWORD,
 )
 
-# Load environment variables from a .env file if present
-def _load_env(path: str = ".env") -> None:
-    """Populate ``os.environ`` from a ``.env`` file if it exists."""
-    if os.path.exists(path):
-        with open(path) as env_file:
-            for raw_line in env_file:
-                line = raw_line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                key, _, value = line.partition("=")
-                os.environ.setdefault(key.strip(), value.strip())
-
-_load_env()
-
 # Default sick leave allocation
 DEFAULT_SICK_LEAVE = 5
 
 # @tweakable server configuration
-ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "mgllanos@gmail.com")
-if not ADMIN_EMAIL:
-    raise RuntimeError("ADMIN_EMAIL environment variable is required")
+ADMIN_EMAIL = "mgllanos@gmail.com"
 ADMIN_USERNAME = "admin"
 ADMIN_PASSWORD = "admin123"
 


### PR DESCRIPTION
## Summary
- inline ADMIN_EMAIL constant and drop .env support
- delete server's `_load_env` helper and missing-variable check
- document baked-in admin email in README

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcfc2e642c83258cf33c8fedb08aaf