### PR TITLE
Add calendar invitation support for notification emails

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -48,6 +48,8 @@ def generate_ics_content(
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
         "PRODID:-//Leave Management System//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:REQUEST",
         "BEGIN:VEVENT",
         f"UID:{uid}",
         f"DTSTAMP:{dtstamp}",
@@ -90,9 +92,10 @@ def send_notification_email(
     if ics_content:
         msg.add_attachment(
             ics_content,
-            maintype="text",
             subtype="calendar",
             filename="event.ics",
+            params={"method": "REQUEST"},
+            headers=["Content-Class: urn:content-classes:calendarmessage"],
         )
 
     try:

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,0 +1,56 @@
+import smtplib
+from email.message import EmailMessage
+from pathlib import Path
+import sys
+
+import pytest
+
+# Ensure the project root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from services.email_service import generate_ics_content, send_notification_email
+
+
+def test_generate_ics_includes_method_request():
+    ics = generate_ics_content("2024-01-01", "2024-01-02", "Vacation")
+    assert "METHOD:REQUEST" in ics
+
+
+def test_send_notification_email_sets_invite_headers(monkeypatch):
+    sent_msg: EmailMessage | None = None
+
+    class DummySMTP:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def starttls(self):
+            pass
+
+        def login(self, username, password):
+            pass
+
+        def send_message(self, msg):
+            nonlocal sent_msg
+            sent_msg = msg
+
+    monkeypatch.setattr(smtplib, "SMTP", DummySMTP)
+
+    ics = generate_ics_content("2024-01-01", "2024-01-02", "Vacation")
+    assert send_notification_email("to@example.com", "Subject", "Body", ics_content=ics)
+
+    assert sent_msg is not None
+    attachments = list(sent_msg.iter_attachments())
+    assert len(attachments) == 1
+    attachment = attachments[0]
+    # Content-Type should include method=REQUEST so email clients treat it as invite
+    content_type = attachment.get("Content-Type")
+    assert content_type is not None
+    assert "method=\"REQUEST\"" in content_type
+    # Custom header used by some clients
+    assert attachment["Content-Class"] == "urn:content-classes:calendarmessage"


### PR DESCRIPTION
## Summary
- include METHOD:REQUEST and CALSCALE in generated ICS events
- send emails with calendar attachments tagged as invitations via method and Content-Class headers
- add tests verifying ICS invite headers are present in the message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcffbe577c83258c85450045552ad1