### PR TITLE
Validate employee email before leave approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ A comprehensive web-based leave management system designed for small to medium o
    SMTP_PASSWORD = "your-app-password"     # Your Gmail App Password
    ```
 
+#### Employee Records
+Ensure each employee record includes a valid `personal_email` address. Leave
+approval will fail if this field is empty, and administrators will be
+notified.
+

--- a/server.py
+++ b/server.py
@@ -525,6 +525,35 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                 emp = cursor.fetchone()
                                 employee_email = emp['personal_email'] if emp else None
 
+                                # Verify employee email before proceeding
+                                if not employee_email:
+                                    warning_subject = f"Employee email missing for {employee_id}"
+                                    warning_body = (
+                                        f"Leave application {record_id} for employee {employee_id} lacks a personal email."
+                                        " Approval cannot proceed until it is set."
+                                    )
+                                    try:
+                                        send_notification_email(
+                                            ADMIN_EMAIL,
+                                            warning_subject,
+                                            warning_body,
+                                            SMTP_SERVER,
+                                            SMTP_PORT,
+                                            SMTP_USERNAME,
+                                            SMTP_PASSWORD,
+                                            ics_content=None,
+                                        )
+                                    except Exception as warn_err:
+                                        print(f"⚠️ Failed to warn admin for {record_id}: {warn_err}")
+                                    if new_status == 'Approved':
+                                        conn.execute(
+                                            'UPDATE leave_applications SET status=?, updated_at=? WHERE id=?',
+                                            (current_status, current_time, record_id),
+                                        )
+                                        conn.commit()
+                                        self.send_error(400, "Employee personal email required for approval")
+                                        return
+
                                 start_date = app_info['start_date']
                                 end_date = app_info['end_date']
                                 total_days = app_info['total_days']

--- a/services/leave_service.py
+++ b/services/leave_service.py
@@ -1,4 +1,8 @@
-"""Service: Leave Service. Handle leave applications and approvals."""
+"""Service: Leave Service. Handle leave applications and approvals.
+
+All employees are expected to have a ``personal_email`` on record. Leave
+approval is aborted if this field is missing.
+"""
 from __future__ import annotations
 
 from typing import Optional
@@ -63,6 +67,14 @@ def approve_leave_request(application_id: str) -> bool:
         return False
 
     start_date, end_date, leave_type, employee_email = row
+
+    if not employee_email:
+        warning = (
+            f"Leave application {application_id} has no associated personal email."
+            " Approval aborted."
+        )
+        send_notification_email(ADMIN_EMAIL, "Missing employee email", warning, ics_content=None)
+        return False
 
     subject = f"Leave Approved: {leave_type}"
     body = (


### PR DESCRIPTION
## Summary
- warn admins and abort leave approval when an employee lacks a personal email
- document personal_email requirement for employees
- guard leave_service approvals against missing emails

## Testing
- `python -m py_compile server.py services/leave_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcffb855948325ad25bf16cdb5e019