### PR TITLE
Require explicit SMTP credentials and document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ A comprehensive web-based leave management system designed for small to medium o
 ### Step 2: Configuration
 
 #### Email Notifications (Optional but Recommended)
-1. Configure your email credentials in `services/email_service.py` or via
-   environment variables.
-2. Replace the default credentials:
-   ```python
-   SMTP_USERNAME = "your-email@gmail.com"  # Your Gmail address
-   SMTP_PASSWORD = "your-app-password"     # Your Gmail App Password
+1. Provide your SMTP credentials via environment variables before starting the
+   application:
+   ```bash
+   export SMTP_USERNAME="your-email@gmail.com"    # Your email address
+   export SMTP_PASSWORD="your-app-password"       # Your SMTP/App password
    ```
+   The service will fail to start if either of these variables is missing.
+2. Optionally override `SMTP_SERVER` and `SMTP_PORT` in the same manner to use a
+   different mail provider.
 

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -14,8 +14,18 @@ from email.message import EmailMessage
 # ``send_notification_email``.
 SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.gmail.com")
 SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
-SMTP_USERNAME = os.getenv("SMTP_USERNAME", "qtaskvacation@gmail.com")
-SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "bicg llyb myff kigu")
+SMTP_USERNAME = os.getenv("SMTP_USERNAME")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+
+missing_creds = []
+if not SMTP_USERNAME:
+    missing_creds.append("SMTP_USERNAME")
+if not SMTP_PASSWORD:
+    missing_creds.append("SMTP_PASSWORD")
+if missing_creds:
+    raise RuntimeError(
+        "Missing required environment variable(s): " + ", ".join(missing_creds)
+    )
 ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@example.com")
 
 


### PR DESCRIPTION
## Summary
- remove hard-coded fallback SMTP credentials
- validate presence of SMTP_USERNAME and SMTP_PASSWORD at startup
- document required SMTP environment variables

## Testing
- `SMTP_USERNAME=dummy SMTP_PASSWORD=dummy python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd01eb19508325b68bdcae98a12e80