### PR TITLE
Raise ConnectionError on DB failure and add tests

### DIFF
--- a/services/database_service.py
+++ b/services/database_service.py
@@ -21,6 +21,7 @@ db_lock = threading.RLock()
 
 def get_db_connection():
     """Get database connection with retry logic"""
+    last_exception = None
     for attempt in range(MAX_DB_RETRIES):
         try:
             conn = sqlite3.connect(DATABASE_PATH, timeout=DB_CONNECTION_TIMEOUT)
@@ -28,9 +29,8 @@ def get_db_connection():
             conn.row_factory = sqlite3.Row  # Enable dict-like access
             return conn
         except sqlite3.Error as e:
-            if attempt == MAX_DB_RETRIES - 1:
-                raise e
-    return None
+            last_exception = e
+    raise ConnectionError(f"Unable to connect to database after {MAX_DB_RETRIES} attempts: {last_exception}")
 
 def init_database():
     """Initialize SQLite database with required tables"""

--- a/services/leave_service.py
+++ b/services/leave_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Optional
+import logging
 
 from .database_service import get_db_connection
 from .email_service import (
@@ -25,8 +26,10 @@ def approve_leave_request(application_id: str) -> bool:
         ``True`` if the request was updated and an email was dispatched,
         otherwise ``False``.
     """
-    conn = get_db_connection()
-    if conn is None:
+    try:
+        conn = get_db_connection()
+    except ConnectionError as e:
+        logging.error(f"Database connection failed: {e}")
         return False
 
     try:

--- a/tests/test_database_connection.py
+++ b/tests/test_database_connection.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the services package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from services import database_service
+
+
+def test_get_db_connection_failure(tmp_path, monkeypatch):
+    # Use a path in a non-existent directory to force connection failure
+    invalid_db_path = tmp_path / "nonexistent" / "db.sqlite"
+    monkeypatch.setattr(database_service, "DATABASE_PATH", str(invalid_db_path))
+    with pytest.raises(ConnectionError):
+        database_service.get_db_connection()
+


### PR DESCRIPTION
## Summary
- raise ConnectionError when database connection attempts fail
- handle database connection errors in services and server with logging
- add test to verify connection failure raises ConnectionError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd01f7837c832591684fb26d1f1974