### PR TITLE
Hardcode SMTP configuration and remove env variable reliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,11 @@ A comprehensive web-based leave management system designed for small to medium o
 
 ### Step 2: Configuration
 
-#### Email Notifications (Optional but Recommended)
-1. Provide your SMTP credentials via environment variables before starting the
-   application:
-   ```bash
-   export SMTP_USERNAME="your-email@gmail.com"    # Your email address
-   export SMTP_PASSWORD="your-app-password"       # Your SMTP/App password
-   ```
-   The service will fail to start if either of these variables is missing.
-2. Optionally override `SMTP_SERVER` and `SMTP_PORT` in the same manner to use a
-   different mail provider.
+#### Email Notifications
+SMTP settings are now hardcoded in `services/email_service.py`, so no environment
+variables are required for configuration. **Warning:** hardcoding credentials is
+insecure. Keep the repository private and consider moving these settings to a
+separate configuration file that is excluded from version control.
 
 #### Employee Records
 Ensure each employee record includes a valid `personal_email` address. Leave

--- a/server.py
+++ b/server.py
@@ -3,7 +3,6 @@ import socketserver
 import json
 import urllib.parse
 import sys
-import os
 import uuid
 import logging
 import sqlite3
@@ -110,8 +109,6 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path.startswith('/api/'):
             self.handle_api_request()
-        elif self.path == '/api/config/admin_email':
-            self.send_json_response({'admin_email': ADMIN_EMAIL})
         else:
             # Serve static files
             super().do_GET()
@@ -173,25 +170,18 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
             try:
                 query = urllib.parse.parse_qs(query_string)
                 
-                # @tweakable handle config endpoint for admin email retrieval
-                if collection == 'config' and len(path_parts) > 3:
-                    config_key = path_parts[3]
-                    if config_key == 'admin_email':
+                if collection == 'config':
+                    # Return admin email configuration
+                    if len(path_parts) > 3:
+                        config_key = path_parts[3]
+                        if config_key == 'admin_email':
+                            results = {'admin_email': ADMIN_EMAIL}
+                            self.send_json_response(results)
+                        else:
+                            self.send_error(404, f"Config key '{config_key}' not found")
+                    else:
                         results = {'admin_email': ADMIN_EMAIL}
                         self.send_json_response(results)
-                        return
-                    else:
-                        self.send_error(404, f"Config key '{config_key}' not found")
-                        return
-                elif collection == 'config':
-                    # Return all config values
-                    results = {
-                        'admin_email': ADMIN_EMAIL,
-                        'smtp_username': SMTP_USERNAME,
-                        'smtp_server': SMTP_SERVER,
-                        'smtp_port': SMTP_PORT,
-                    }
-                    self.send_json_response(results)
                     return
                 
                 if collection == 'employee':

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -1,32 +1,18 @@
-"""
-Service: Email Service. Purpose: Send notifications and alerts via SMTP.
-"""
+"""Service: Email Service. Purpose: Send notifications and alerts via SMTP."""
 
-import os
 import smtplib
 import uuid
 from datetime import datetime, timedelta
 from email.message import EmailMessage
 
 
-# Default configuration can be provided via environment variables. These values
-# are only used if explicit settings are not supplied when calling
-# ``send_notification_email``.
-SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.gmail.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
-SMTP_USERNAME = os.getenv("SMTP_USERNAME")
-SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+# Static SMTP configuration used for all outbound email.
+SMTP_SERVER = "smtp.example.com"
+SMTP_PORT = 587
+SMTP_USERNAME = "user@example.com"
+SMTP_PASSWORD = "password"
 
-missing_creds = []
-if not SMTP_USERNAME:
-    missing_creds.append("SMTP_USERNAME")
-if not SMTP_PASSWORD:
-    missing_creds.append("SMTP_PASSWORD")
-if missing_creds:
-    raise RuntimeError(
-        "Missing required environment variable(s): " + ", ".join(missing_creds)
-    )
-ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@example.com")
+ADMIN_EMAIL = "admin@example.com"
 
 
 def _sanitize_ics_text(value: str) -> str:
@@ -103,8 +89,7 @@ def send_notification_email(
 ) -> bool:
     """Send notification email via SMTP with configurable settings."""
 
-    # Fall back to module level constants or environment variables if explicit
-    # credentials were not supplied.
+    # Fall back to module level constants if explicit credentials were not supplied.
     username = username or SMTP_USERNAME
     password = password or SMTP_PASSWORD
 


### PR DESCRIPTION
## Summary
- Replace SMTP environment variable lookups with fixed credentials in email service
- Drop server endpoints exposing SMTP configuration and remove unused imports
- Document hardcoded SMTP settings and security considerations in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd0e18ea188325ba3ce8cf04868ec0