### PR TITLE
Handle email notification failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 # Local environment variables
 .env
 
+# Server log files
+server.log
+

--- a/script.js
+++ b/script.js
@@ -84,11 +84,18 @@ class BackendCollection {
                 }
                 
                 const result = await response.json();
-                
+
+                if (result && Array.isArray(result.email_errors) && result.email_errors.length > 0) {
+                    const summary = result.email_errors
+                        .map(err => `${err.recipient}: ${err.error}`)
+                        .join('\n');
+                    alert(`Warning: Failed to send notification emails:\n${summary}`);
+                }
+
                 if (this.database.debugMode) {
                     console.log(`SUCCESS ${method} ${url} success`, result);
                 }
-                
+
                 return result;
                 
             } catch (error) {


### PR DESCRIPTION
## Summary
- Log server activity to file and stdout
- Return `email_errors` when notification emails fail
- Alert users in the UI if any emails were not delivered

## Testing
- `python -m py_compile server.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd98d3b35883259013f8128639594c