### PR TITLE
Add admin action confirmation modal for status updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,22 @@
             </div>
         </div>
 
+        <!-- Admin Action Modal -->
+        <div id="adminActionModal" class="modal">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2>✅ Application Updated</h2>
+                </div>
+                <div class="modal-body">
+                    <p><strong>Application ID:</strong> <span id="adminApplicationId"></span></p>
+                    <p><strong>New Status:</strong> <span id="adminNewStatus"></span></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" id="adminActionClose" class="btn-primary">Close</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Error Modal for Insufficient Balance -->
         <div id="errorModal" class="modal">
             <div class="modal-content">

--- a/script.js
+++ b/script.js
@@ -1698,7 +1698,30 @@ async function updateApplicationStatus(id, newStatus) {
         await loadLeaveApplications();
         await loadEmployeeSummary();
         await loadEmployeeList();
-        alert('Application status updated successfully');
+
+        const modal = document.getElementById('adminActionModal');
+        if (modal) {
+            const idSpan = document.getElementById('adminApplicationId');
+            const statusSpan = document.getElementById('adminNewStatus');
+            if (idSpan) idSpan.textContent = id;
+            if (statusSpan) statusSpan.textContent = newStatus;
+
+            const closeBtn = document.getElementById('adminActionClose');
+            if (closeBtn) {
+                closeBtn.addEventListener(
+                    'click',
+                    () => {
+                        modal.classList.remove('show');
+                        actionButtons.forEach(btn => (btn.disabled = false));
+                    },
+                    { once: true }
+                );
+            }
+
+            modal.classList.add('show');
+        } else {
+            actionButtons.forEach(btn => (btn.disabled = false));
+        }
     } catch (error) {
         const requestUrl = `leave_application/${id}`;
         const status = error?.response?.status || error.status;
@@ -1721,8 +1744,8 @@ async function updateApplicationStatus(id, newStatus) {
             originalError: error,
         });
         alert(`Failed to update application status for ID ${id}. ${status ? `Status: ${status}.` : ''}`);
-    } finally {
         actionButtons.forEach(btn => (btn.disabled = false));
+    } finally {
         hideLoading();
     }
 }


### PR DESCRIPTION
## Summary
- Add an Admin Action modal to show application ID and new status after updates
- Populate and display the modal instead of alert when admins change an application
- Close button now hides the modal and re-enables action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd998dd438832583a836e98bd66a35