### PR TITLE
Track email send status in updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -1694,11 +1694,17 @@ async function updateApplicationStatus(id, newStatus) {
     actionButtons.forEach(btn => (btn.disabled = true));
 
     try {
-        await room.collection('leave_application').update(id, { status: newStatus });
+        const result = await room.collection('leave_application').update(id, { status: newStatus });
         await loadLeaveApplications();
         await loadEmployeeSummary();
         await loadEmployeeList();
-        alert('Application status updated successfully');
+
+        const emailStatus = result?.email_status || {};
+        if (emailStatus.admin && emailStatus.employee) {
+            document.getElementById('successModal').classList.add('show');
+        } else {
+            alert('Application updated but email notification failed');
+        }
     } catch (error) {
         const requestUrl = `leave_application/${id}`;
         const status = error?.response?.status || error.status;


### PR DESCRIPTION
## Summary
- send notification emails before responding in update flow
- include per-recipient email_status in update responses
- show success modal only when admin and employee emails send successfully

## Testing
- `python -m py_compile server.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd998fd0dc83259ca758afc8891c24