### PR TITLE
Handle logging setup failures

### DIFF
--- a/server.py
+++ b/server.py
@@ -35,6 +35,19 @@ from services.email_service import (
     SMTP_PASSWORD,
 )
 
+# Configure logging to write to ``server.log`` if possible.  If creating the
+# log file fails (e.g. due to permissions issues), fall back to logging to
+# ``stderr`` so the server can still run.
+try:
+    file_handler = logging.FileHandler("server.log")
+    logging.basicConfig(level=logging.INFO, handlers=[file_handler, logging.StreamHandler()])
+except Exception as log_err:  # noqa: BLE001 - broad exception to keep server running
+    logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+    logging.warning(
+        "Falling back to stderr logging because server.log could not be opened: %s",
+        log_err,
+    )
+
 # Load environment variables from a .env file if present
 def _load_env(path: str = ".env") -> None:
     """Populate ``os.environ`` from a ``.env`` file if it exists."""


### PR DESCRIPTION
## Summary
- ensure server logging initialization handles failures by falling back to stderr and warning users

## Testing
- `python -m py_compile server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bda0655aec832592a9c37ce5ab3f80