### PR TITLE
Remove placeholder _todo functions

### DIFF
--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -443,7 +443,3 @@ def update_balances_from_admin_edit(employee_id, new_remaining_pl, new_remaining
             raise e
         finally:
             conn.close()
-
-def _todo():
-    """Placeholder to keep the module importable."""
-    return None

--- a/services/employee_service.py
+++ b/services/employee_service.py
@@ -182,7 +182,3 @@ def _validate_employee_update_data(conn, employee_id, data):
         cursor = conn.execute('SELECT id FROM employees WHERE personal_email = ? AND id != ? AND is_active = 1', (email, employee_id))
         if cursor.fetchone():
             raise ValueError(f"Employee with email {email} already exists")
-
-def _todo():
-    """Placeholder to keep the module importable."""
-    return None


### PR DESCRIPTION
## Summary
- delete unused `_todo` placeholders from `employee_service` and `balance_manager`
- ensure modules end with functional code only

## Testing
- `python -m py_compile services/employee_service.py services/balance_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdabfb33fc832597730f70aceab181