### PR TITLE
chore: remove placeholder todo from balance manager

### DIFF
--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -443,7 +443,3 @@ def update_balances_from_admin_edit(employee_id, new_remaining_pl, new_remaining
             raise e
         finally:
             conn.close()
-
-def _todo():
-    """Placeholder to keep the module importable."""
-    return None


### PR DESCRIPTION
## Summary
- remove leftover `_todo` placeholder from balance manager

## Testing
- `python -m py_compile services/balance_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdafe0682083258f39c871f35db7e8