### PR TITLE
Remove placeholder _todo function from employee service

### DIFF
--- a/services/employee_service.py
+++ b/services/employee_service.py
@@ -182,7 +182,3 @@ def _validate_employee_update_data(conn, employee_id, data):
         cursor = conn.execute('SELECT id FROM employees WHERE personal_email = ? AND id != ? AND is_active = 1', (email, employee_id))
         if cursor.fetchone():
             raise ValueError(f"Employee with email {email} already exists")
-
-def _todo():
-    """Placeholder to keep the module importable."""
-    return None


### PR DESCRIPTION
## Summary
- remove unused `_todo` stub and merge markers from `employee_service`

## Testing
- `python -m py_compile services/employee_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdafe2cdcc8325ba1c3bd6b3e963ae