### PR TITLE
Use logging.exception for email send failures

### DIFF
--- a/server.py
+++ b/server.py
@@ -810,11 +810,11 @@ HR Department
                         )
                 except Exception as email_err:  # noqa: BLE001 - unexpected failure
                     email_status[recipient] = False
-                    logging.error(
-                        "Failed to send email to %s for application %s: %s",
+                    logging.exception(
+                        "Failed to send email '%s' to %s for application %s",
+                        subject,
                         to_addr,
                         record_id,
-                        email_err,
                     )
 
             if response_payload is not None:


### PR DESCRIPTION
## Summary
- Log exception details when email dispatch fails, including subject and recipient
- Leave recoverable warning log messages unchanged

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdb37a00dc8325a04ac7b0c4d387a5