### PR TITLE
Remove maintype from ICS attachment

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -117,7 +117,6 @@ def send_notification_email(
     if ics_content:
         msg.add_attachment(
             ics_content,
-            maintype="text",
             subtype="calendar",
             filename="event.ics",
             params={"method": "REQUEST"},


### PR DESCRIPTION
## Summary
- remove `maintype="text"` from calendar attachment in `send_notification_email`

## Testing
- `python -m py_compile services/email_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb46d2a9c83259bb2bfe866eb9d8a