### PR TITLE
Inline calendar events in notification emails

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -116,12 +116,12 @@ def send_notification_email(
             msg.add_alternative(html_body, subtype="html")
 
         if ics_content:
-            msg.add_attachment(
+            msg.add_alternative(
                 ics_content,
                 subtype="calendar",
-                filename="event.ics",
                 params={"method": "REQUEST"},
             )
+            msg["Content-Class"] = "urn:content-classes:calendarmessage"
 
         logging.debug(
             "Sending email to %s with subject %s; ICS attached: %s",

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,0 +1,44 @@
+from services import email_service
+
+
+def test_send_notification_email_inlines_ics(monkeypatch):
+    captured = {}
+
+    class DummySMTP:
+        def __init__(self, server, port):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def starttls(self):
+            pass
+
+        def login(self, username, password):
+            pass
+
+        def send_message(self, msg):
+            captured['msg'] = msg
+
+    monkeypatch.setattr(email_service.smtplib, "SMTP", DummySMTP)
+
+    ok, err = email_service.send_notification_email(
+        to_addr="test@example.com",
+        subject="Test", 
+        body="Body",
+        ics_content="BEGIN:VCALENDAR\r\nEND:VCALENDAR",
+    )
+
+    assert ok and err is None
+    msg = captured['msg']
+    # Should have an inline text/calendar part
+    calendar_part = msg.get_body(("calendar",))
+    assert calendar_part is not None
+    assert calendar_part.get_content_type() == "text/calendar"
+    # No attachments expected
+    assert list(msg.iter_attachments()) == []
+    # Optional header for compatibility
+    assert msg["Content-Class"] == "urn:content-classes:calendarmessage"


### PR DESCRIPTION
## Summary
- Replace `.ics` file attachments with inline `text/calendar` parts in notification emails
- Add optional Content-Class header for better client compatibility
- Add unit test verifying calendar events are sent inline without attachments

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be00c55df483258e47b6c051056c0b