### PR TITLE
Add workday helper tests and return date notifications

### DIFF
--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,4 +1,10 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from services import email_service
+from server import format_leave_decision_email, next_workday
 
 
 def test_send_notification_email_inlines_ics(monkeypatch):
@@ -42,3 +48,32 @@ def test_send_notification_email_inlines_ics(monkeypatch):
     assert list(msg.iter_attachments()) == []
     # Optional header for compatibility
     assert msg["Content-Class"] == "urn:content-classes:calendarmessage"
+
+
+def test_decision_notifications_include_return_date():
+    holidays = {"2023-07-04"}
+    return_date = next_workday("2023-07-03", holidays)
+    admin_body = format_leave_decision_email(
+        "admin",
+        "Alice",
+        "APP-1",
+        "Annual",
+        "2023-07-01",
+        "2023-07-03",
+        1,
+        return_date,
+        "approved",
+    )
+    employee_body = format_leave_decision_email(
+        "employee",
+        "Alice",
+        "APP-1",
+        "Annual",
+        "2023-07-01",
+        "2023-07-03",
+        1,
+        return_date,
+        "approved",
+    )
+    assert return_date in admin_body
+    assert return_date in employee_body

--- a/tests/test_employee_reactivation.py
+++ b/tests/test_employee_reactivation.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 import pytest
 
 from services import database_service, employee_service

--- a/tests/test_next_workday.py
+++ b/tests/test_next_workday.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+from server import next_workday
+
+
+def test_next_workday_skips_weekends():
+    # Friday -> following Monday
+    result = next_workday("2023-07-14", set())
+    assert result == "2023-07-17"
+
+
+def test_next_workday_respects_holidays():
+    # Monday with Tuesday holiday -> Wednesday
+    holidays = {"2023-07-18"}
+    result = next_workday("2023-07-17", holidays)
+    assert result == "2023-07-19"
+
+
+def test_next_workday_invalid_input_returns_none():
+    assert next_workday("invalid", set()) is None
+    assert next_workday("", set()) is None


### PR DESCRIPTION
## Summary
- Add `next_workday` tests for weekends, holidays, and invalid input
- Include computed return date in approval/rejection notifications
- Cover decision notifications with integration tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be2f928db083258637c2953c9c834b