### PR TITLE
Switch leave tracking to hourly durations

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,38 +115,14 @@
                         <div class="date-group">
                             <label for="startDate">Start Date:</label>
                             <input type="date" id="startDate" name="startDate" required>
-                            <div class="half-day-options">
-                                <label class="radio-label">
-                                    <input type="radio" name="startDayType" value="full" checked>
-                                    Full Day
-                                </label>
-                                <label class="radio-label">
-                                    <input type="radio" name="startDayType" value="am">
-                                    AM Only
-                                </label>
-                                <label class="radio-label">
-                                    <input type="radio" name="startDayType" value="pm">
-                                    PM Only
-                                </label>
-                            </div>
+                            <label for="startTime" class="time-label">Start Time:</label>
+                            <input type="time" id="startTime" name="startTime" step="60" required value="09:00">
                         </div>
                         <div class="date-group">
                             <label for="endDate">End Date:</label>
                             <input type="date" id="endDate" name="endDate" required>
-                            <div class="half-day-options">
-                                <label class="radio-label">
-                                    <input type="radio" name="endDayType" value="full" checked>
-                                    Full Day
-                                </label>
-                                <label class="radio-label">
-                                    <input type="radio" name="endDayType" value="am">
-                                    AM Only
-                                </label>
-                                <label class="radio-label">
-                                    <input type="radio" name="endDayType" value="pm">
-                                    PM Only
-                                </label>
-                            </div>
+                            <label for="endTime" class="time-label">End Time:</label>
+                            <input type="time" id="endTime" name="endTime" step="60" required value="17:00">
                         </div>
                     </div>
                     <div class="duration-display">

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -27,6 +27,8 @@ def generate_ics_content(
     end_date: str,
     summary: str,
     description: str | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
 ) -> str:
     """Create a basic ICS calendar event.
 
@@ -42,8 +44,6 @@ def generate_ics_content(
         Optional description to include with the event.
     """
 
-    start_dt = datetime.fromisoformat(start_date)
-    end_dt = datetime.fromisoformat(end_date) + timedelta(days=1)
     uid = f"{uuid.uuid4()}@leave-management-system"
     dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
 
@@ -55,10 +55,24 @@ def generate_ics_content(
         "BEGIN:VEVENT",
         f"UID:{uid}",
         f"DTSTAMP:{dtstamp}",
-        f"DTSTART;VALUE=DATE:{start_dt.strftime('%Y%m%d')}",
-        f"DTEND;VALUE=DATE:{end_dt.strftime('%Y%m%d')}",
-        f"SUMMARY:{summary}",
     ]
+
+    if start_time or end_time:
+        start_clock = start_time or "00:00"
+        end_clock = end_time or start_clock
+        start_dt = datetime.fromisoformat(f"{start_date}T{start_clock}")
+        end_dt = datetime.fromisoformat(f"{end_date}T{end_clock}")
+        if end_dt <= start_dt:
+            end_dt = start_dt + timedelta(hours=1)
+        lines.append(f"DTSTART:{start_dt.strftime('%Y%m%dT%H%M%S')}")
+        lines.append(f"DTEND:{end_dt.strftime('%Y%m%dT%H%M%S')}")
+    else:
+        start_dt = datetime.fromisoformat(start_date)
+        end_dt = datetime.fromisoformat(end_date) + timedelta(days=1)
+        lines.append(f"DTSTART;VALUE=DATE:{start_dt.strftime('%Y%m%d')}")
+        lines.append(f"DTEND;VALUE=DATE:{end_dt.strftime('%Y%m%d')}")
+
+    lines.append(f"SUMMARY:{summary}")
 
     if description:
         lines.append(f"DESCRIPTION:{description}")


### PR DESCRIPTION
## Summary
- extend the database schema and balance processing to store leave start/end times, hourly totals, and backfill missing columns
- calculate hourly durations on the server, include the information in notification emails/calendar invites, and convert them to days when adjusting balances
- update the leave request form and dashboards to capture start/end times, compute hourly totals client-side, and show combined hour/day durations in all tables

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4bfb4674083258b71403a58ce34ec