### PR TITLE
Fix leave application insert placeholder count

### DIFF
--- a/server.py
+++ b/server.py
@@ -591,7 +591,7 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                     start_time, end_time, start_day_type, end_day_type, leave_type,
                                     selected_reasons, reason, total_hours, total_days, status, date_applied,
                                     created_at, updated_at
-                                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                                 ''',
                                 (
                                     record_id,


### PR DESCRIPTION
## Summary
- fix the leave application INSERT statement to provide a placeholder for each column value

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ccbc57288325946fe04ff09433a7