### PR TITLE
Cap daily leave hours and align frontend/backend calculations

### DIFF
--- a/tests/test_hours_calculation.py
+++ b/tests/test_hours_calculation.py
@@ -1,0 +1,22 @@
+import math
+
+from server import WORK_HOURS_PER_DAY, calculate_total_days, calculate_total_hours
+
+
+def test_multi_day_request_is_capped_per_day():
+    hours = calculate_total_hours(
+        "2025-09-29",
+        "2025-10-02",
+        start_time="08:00",
+        end_time="17:00",
+    )
+    assert math.isclose(hours, 32.0, rel_tol=0, abs_tol=1e-6)
+
+    days = calculate_total_days(
+        "2025-09-29",
+        "2025-10-02",
+        start_time="08:00",
+        end_time="17:00",
+    )
+    assert math.isclose(days, 4.0, rel_tol=0, abs_tol=1e-6)
+    assert hours == WORK_HOURS_PER_DAY * days


### PR DESCRIPTION
## Summary
- cap the frontend total-hours calculator to at most the standard workday per weekday while honouring boundary start/end times
- mirror the same daily capping logic in the backend `calculate_total_hours` implementation for consistent validation
- add a regression test covering a multi-day request that expects exactly 32 hours / 4 days of leave

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d74c1a07288325859814f06701def9