### PR TITLE
Adjust default vacation times

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,13 +116,13 @@
                             <label for="startDate">Start Date:</label>
                             <input type="date" id="startDate" name="startDate" required>
                             <label for="startTime" class="time-label">Start Time:</label>
-                            <input type="time" id="startTime" name="startTime" step="60" required value="09:00">
+                            <input type="time" id="startTime" name="startTime" step="60" required value="06:30">
                         </div>
                         <div class="date-group">
                             <label for="endDate">End Date:</label>
                             <input type="date" id="endDate" name="endDate" required>
                             <label for="endTime" class="time-label">End Time:</label>
-                            <input type="time" id="endTime" name="endTime" step="60" required value="17:00">
+                            <input type="time" id="endTime" name="endTime" step="60" required value="15:00">
                         </div>
                     </div>
                     <div class="duration-display">


### PR DESCRIPTION
## Summary
- update the default start and end times for vacation requests to 6:30 AM and 3:00 PM

## Testing
- Visually verified in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d74e43b5848325965952b9bf8c395d