### PR TITLE
Handle cash-out as privilege leave

### DIFF
--- a/script.js
+++ b/script.js
@@ -1724,7 +1724,7 @@ async function loadEmployeeSummary() {
             }
 
             if (app.status === 'Approved') {
-                const privilegeTypes = ['privilege', 'pl', 'vacation-annual', 'personal'];
+                const privilegeTypes = ['privilege', 'pl', 'vacation-annual', 'personal', 'cash-out'];
                 const sickTypes = ['sick', 'sl'];
 
                 if (privilegeTypes.includes(type)) {

--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -20,7 +20,7 @@ ENABLE_BALANCE_AUDIT = True
 # These correspond to the `value` attributes in index.html
 # Store privilege leave types as lowercase values to allow
 # case-insensitive matching when processing leave types
-PRIVILEGE_LEAVE_TYPES = {t.lower() for t in {'personal', 'vacation-annual'}}
+PRIVILEGE_LEAVE_TYPES = {t.lower() for t in {'personal', 'vacation-annual', 'cash-out'}}
 NON_DEDUCTIBLE_LEAVE_TYPES = {'leave-without-pay'}
 ADMIN_CAN_EDIT_REMAINING_LEAVE = True
 DEFAULT_PRIVILEGE_LEAVE = 15

--- a/tests/test_balance_manager.py
+++ b/tests/test_balance_manager.py
@@ -91,3 +91,99 @@ def test_leave_without_pay_does_not_adjust_balances(tmp_path):
         assert after_rejection == initial_balances
     finally:
         database_service.DATABASE_PATH = original_db_path
+
+
+def test_cash_out_counts_as_privilege_leave(tmp_path):
+    original_db_path = database_service.DATABASE_PATH
+    test_db_path = tmp_path / 'test_cash_out_privilege.db'
+    database_service.DATABASE_PATH = str(test_db_path)
+
+    try:
+        database_service.init_database()
+
+        employee = employee_service.create_employee(
+            {
+                'first_name': 'Cash',
+                'surname': 'Out',
+                'personal_email': 'cash.out@example.com',
+                'annual_leave': 12,
+                'sick_leave': 6,
+            }
+        )
+
+        employee_id = employee['id']
+        balance_manager.initialize_employee_balances(employee_id)
+
+        def fetch_balances():
+            conn = database_service.get_db_connection()
+            try:
+                cursor = conn.execute(
+                    'SELECT balance_type, used_days, remaining_days FROM leave_balances WHERE employee_id = ?',
+                    (employee_id,),
+                )
+                return {
+                    row['balance_type']: {
+                        'used': row['used_days'],
+                        'remaining': row['remaining_days'],
+                    }
+                    for row in cursor.fetchall()
+                }
+            finally:
+                conn.close()
+
+        initial_balances = fetch_balances()
+
+        application_id = str(uuid.uuid4())
+        public_application_id = str(uuid.uuid4())
+
+        total_days = 2.5
+
+        with database_service.db_lock:
+            conn = database_service.get_db_connection()
+            try:
+                conn.execute(
+                    '''
+                    INSERT INTO leave_applications (
+                        id, application_id, employee_id, employee_name, start_date, end_date,
+                        start_time, end_time, start_day_type, end_day_type, leave_type,
+                        selected_reasons, reason, total_hours, total_days, status
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ''',
+                    (
+                        application_id,
+                        public_application_id,
+                        employee_id,
+                        'Cash Out',
+                        '2024-02-01',
+                        '2024-02-01',
+                        None,
+                        None,
+                        'full',
+                        'full',
+                        'cash-out',
+                        '',
+                        '',
+                        0.0,
+                        total_days,
+                        'Pending',
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        balance_manager.process_leave_application_balance(application_id, 'Approved', changed_by='TEST')
+        after_approval = fetch_balances()
+
+        privilege_initial = initial_balances['PRIVILEGE']
+        privilege_after = after_approval['PRIVILEGE']
+
+        assert privilege_after['used'] == privilege_initial['used'] + total_days
+        assert privilege_after['remaining'] == privilege_initial['remaining'] - total_days
+
+        balance_manager.process_leave_application_balance(application_id, 'Rejected', changed_by='TEST')
+        after_rejection = fetch_balances()
+
+        assert after_rejection == initial_balances
+    finally:
+        database_service.DATABASE_PATH = original_db_path


### PR DESCRIPTION
## Summary
- include cash-out in the set of leave types that deduct privilege balances
- count cash-out requests as privilege leave usage in employee summaries
- add a unit test covering privilege balance adjustments for cash-out requests

## Testing
- python -m pytest tests/test_balance_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d7553f24c48325a92f4caee5d6992a