### PR TITLE
Add cash-out leave selection option

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,11 @@
                             Vacation / Annual Leave
                         </label>
                         <label class="option-label">
+                            <input type="radio" name="leaveType" value="cash-out">
+                            <span class="checkmark"></span>
+                            Cash out Leave
+                        </label>
+                        <label class="option-label">
                             <input type="radio" name="leaveType" value="bereavement">
                             <span class="checkmark"></span>
                             Bereavement / Funeral

--- a/script.js
+++ b/script.js
@@ -1724,7 +1724,7 @@ async function loadEmployeeSummary() {
             }
 
             if (app.status === 'Approved') {
-                const privilegeTypes = ['privilege', 'pl', 'vacation-annual', 'personal'];
+                const privilegeTypes = ['privilege', 'pl', 'vacation-annual', 'personal', 'cash-out'];
                 const sickTypes = ['sick', 'sl'];
 
                 if (privilegeTypes.includes(type)) {

--- a/services/balance_manager.py
+++ b/services/balance_manager.py
@@ -20,7 +20,7 @@ ENABLE_BALANCE_AUDIT = True
 # These correspond to the `value` attributes in index.html
 # Store privilege leave types as lowercase values to allow
 # case-insensitive matching when processing leave types
-PRIVILEGE_LEAVE_TYPES = {t.lower() for t in {'personal', 'vacation-annual'}}
+PRIVILEGE_LEAVE_TYPES = {t.lower() for t in {'personal', 'vacation-annual', 'cash-out'}}
 NON_DEDUCTIBLE_LEAVE_TYPES = {'leave-without-pay'}
 ADMIN_CAN_EDIT_REMAINING_LEAVE = True
 DEFAULT_PRIVILEGE_LEAVE = 15


### PR DESCRIPTION
## Summary
- add a cash-out privilege leave option to the employee leave request form
- treat cash-out requests as privilege leave in client- and server-side balance calculations

## Testing
- python - <<'PY' from pathlib import Path
text = Path('index.html').read_text()
print('value="cash-out" present:', 'value="cash-out"' in text)
print('option-label for cash-out present:', 'Cash out Leave' in text)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d755423f048325b7de8463d4ed675d