### PR TITLE
Allow balance updates to reuse caller transactions

### DIFF
--- a/server.py
+++ b/server.py
@@ -984,7 +984,12 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                         # Process balance changes if status changed
                         if current_status and current_status != new_status:
                             try:
-                                process_leave_application_balance(record_id, new_status, 'ADMIN')
+                                process_leave_application_balance(
+                                    record_id,
+                                    new_status,
+                                    'ADMIN',
+                                    conn=conn,
+                                )
                             except ValueError as balance_error:
                                 conn.rollback()
                                 self.send_error(400, str(balance_error))

--- a/tests/test_balance_manager.py
+++ b/tests/test_balance_manager.py
@@ -187,3 +187,145 @@ def test_cash_out_counts_as_privilege_leave(tmp_path):
         assert after_rejection == initial_balances
     finally:
         database_service.DATABASE_PATH = original_db_path
+
+
+def test_leave_status_updates_share_transaction(tmp_path):
+    original_db_path = database_service.DATABASE_PATH
+    test_db_path = tmp_path / 'test_leave_status_updates_share_transaction.db'
+    database_service.DATABASE_PATH = str(test_db_path)
+
+    try:
+        database_service.init_database()
+
+        employee = employee_service.create_employee(
+            {
+                'first_name': 'Share',
+                'surname': 'Transaction',
+                'personal_email': 'share.transaction@example.com',
+                'annual_leave': 10,
+                'sick_leave': 5,
+            }
+        )
+
+        employee_id = employee['id']
+        balance_manager.initialize_employee_balances(employee_id)
+
+        def fetch_balances():
+            conn = database_service.get_db_connection()
+            try:
+                cursor = conn.execute(
+                    'SELECT balance_type, used_days, remaining_days FROM leave_balances WHERE employee_id = ?',
+                    (employee_id,),
+                )
+                return {
+                    row['balance_type']: {
+                        'used': row['used_days'],
+                        'remaining': row['remaining_days'],
+                    }
+                    for row in cursor.fetchall()
+                }
+            finally:
+                conn.close()
+
+        def fetch_status():
+            conn = database_service.get_db_connection()
+            try:
+                cursor = conn.execute(
+                    'SELECT status FROM leave_applications WHERE id = ?',
+                    (application_id,),
+                )
+                row = cursor.fetchone()
+                return row['status'] if row else None
+            finally:
+                conn.close()
+
+        initial_balances = fetch_balances()
+
+        application_id = str(uuid.uuid4())
+        public_application_id = str(uuid.uuid4())
+        total_days = 1.5
+
+        with database_service.db_lock:
+            conn = database_service.get_db_connection()
+            try:
+                conn.execute(
+                    '''
+                    INSERT INTO leave_applications (
+                        id, application_id, employee_id, employee_name, start_date, end_date,
+                        start_time, end_time, start_day_type, end_day_type, leave_type,
+                        selected_reasons, reason, total_hours, total_days, status
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ''',
+                    (
+                        application_id,
+                        public_application_id,
+                        employee_id,
+                        'Share Transaction',
+                        '2024-03-01',
+                        '2024-03-02',
+                        None,
+                        None,
+                        'full',
+                        'full',
+                        'vacation-annual',
+                        '',
+                        '',
+                        0.0,
+                        total_days,
+                        'Pending',
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        # Approve within a shared transaction/connection context
+        with database_service.db_lock:
+            conn = database_service.get_db_connection()
+            try:
+                conn.execute(
+                    'UPDATE leave_applications SET status = ? WHERE id = ?',
+                    ('Approved', application_id),
+                )
+                balance_manager.process_leave_application_balance(
+                    application_id,
+                    'Approved',
+                    changed_by='TEST',
+                    conn=conn,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        after_approval = fetch_balances()
+        privilege_initial = initial_balances['PRIVILEGE']
+        privilege_after = after_approval['PRIVILEGE']
+
+        assert privilege_after['used'] == privilege_initial['used'] + total_days
+        assert privilege_after['remaining'] == privilege_initial['remaining'] - total_days
+        assert fetch_status() == 'Approved'
+
+        # Reject within a shared transaction/connection context
+        with database_service.db_lock:
+            conn = database_service.get_db_connection()
+            try:
+                conn.execute(
+                    'UPDATE leave_applications SET status = ? WHERE id = ?',
+                    ('Rejected', application_id),
+                )
+                balance_manager.process_leave_application_balance(
+                    application_id,
+                    'Rejected',
+                    changed_by='TEST',
+                    conn=conn,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        after_rejection = fetch_balances()
+
+        assert after_rejection == initial_balances
+        assert fetch_status() == 'Rejected'
+    finally:
+        database_service.DATABASE_PATH = original_db_path


### PR DESCRIPTION
## Summary
- allow balance manager helpers to reuse an external SQLite connection so balance adjustments participate in the caller's transaction
- pass the leave application PUT handler's connection into the balance processor to keep approval updates atomic
- add a regression test that approves and rejects a leave request within a shared transaction to prevent database-locked errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d75945be508325990e5c1a5579629f