### PR TITLE
Add unpaid leave hour tracking to history tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@
                                 <th>Start Date</th>
                                 <th>End Date</th>
                                 <th>Total Days</th>
+                                <th>Unpaid Hours</th>
                                 <th>Status</th>
                             </tr>
                         </thead>
@@ -382,6 +383,7 @@
                                     <th>Leave Type</th>
                                     <th>Dates</th>
                                     <th>Total Days</th>
+                                    <th>Unpaid Hours</th>
                                 </tr>
                             </thead>
                             <tbody id="adminHistoryTableBody"></tbody>


### PR DESCRIPTION
## Summary
- replace the unpaid application helper with a map that retains the negative balance remainder and formatted hours
- surface the formatted unpaid hours for employee and admin leave history rows while keeping the total duration column
- add an "Unpaid Hours" header column to both leave history tables to align with the new data cells

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d765cb2988832596aa730dc2c73a81