### PR TITLE
Rename Total Days headers to Paid Hours

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
                                 <th>Leave Type</th>
                                 <th>Start Date</th>
                                 <th>End Date</th>
-                                <th>Total Days</th>
+                                <th>Paid Hours</th>
                                 <th>Unpaid Hours</th>
                                 <th>Status</th>
                             </tr>
@@ -334,7 +334,7 @@
                                     <th>Leave Type</th>
                                     <th>Start Date</th>
                                     <th>End Date</th>
-                                    <th>Total Days</th>
+                                    <th>Paid Hours</th>
                                     <th>Status</th>
                                     <th>Actions</th>
                                 </tr>
@@ -382,7 +382,7 @@
                                     <th>Employee</th>
                                     <th>Leave Type</th>
                                     <th>Dates</th>
-                                    <th>Total Days</th>
+                                    <th>Paid Hours</th>
                                     <th>Unpaid Hours</th>
                                 </tr>
                             </thead>


### PR DESCRIPTION
## Summary
- rename the Total Days column headers in the employee, admin, and application tables to Paid Hours
- keep the Unpaid Hours column alignment to present the two hour fields together

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76b1ee4bc8325b23b13feef3418e7