### PR TITLE
Refine leave history paid and unpaid hour reporting

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@
                                 <th>Start Date</th>
                                 <th>End Date</th>
                                 <th>Total Days</th>
+                                <th>Paid Hours</th>
                                 <th>Unpaid Hours</th>
                                 <th>Status</th>
                             </tr>
@@ -383,6 +384,7 @@
                                     <th>Leave Type</th>
                                     <th>Dates</th>
                                     <th>Total Days</th>
+                                    <th>Paid Hours</th>
                                     <th>Unpaid Hours</th>
                                 </tr>
                             </thead>


### PR DESCRIPTION
## Summary
- derive paid and unpaid hour allocations from balance history change amounts
- display formatted paid and unpaid hours in employee and admin leave history tables
- add paid hours columns to the history tables and keep unpaid leave labeling consistent with the hour split

## Testing
- python server.py

------
https://chatgpt.com/codex/tasks/task_e_68d76b24c5b88325a50d9c782a2a14b7