### PR TITLE
Highlight unpaid hours in admin history

### DIFF
--- a/script.js
+++ b/script.js
@@ -2034,7 +2034,7 @@ async function loadAdminLeaveHistory(search = '') {
                 <td>${app.start_date} ${app.start_time || ''} - ${app.end_date} ${app.end_time || ''}</td>
                 <td>${formatDurationFromHours(totalHours)}</td>
                 <td>${formatHours(paidHours)}</td>
-                <td>${formatHours(unpaidHours)}</td>
+                <td class="unpaid-hours">${formatHours(unpaidHours)}</td>
             `;
             tbody.appendChild(tr);
         });

--- a/styles.css
+++ b/styles.css
@@ -378,6 +378,11 @@ th, td {
     min-width: 120px;
 }
 
+.unpaid-hours {
+    color: var(--error-color);
+    font-weight: 600;
+}
+
 th {
     background: var(--background);
     font-weight: 600;


### PR DESCRIPTION
## Summary
- add a dedicated CSS class to the unpaid-hours column in the admin leave history table
- style the new class so unpaid hours appear red and bold, including in exported PDFs that reuse the table markup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d869803ab88325adeff8b60d96869a