### PR TITLE
Normalize cash out leave types

### DIFF
--- a/script.js
+++ b/script.js
@@ -1963,7 +1963,10 @@ async function loadLeaveHistory(employeeId, status = null) {
             }
 
             const leaveTypeValue = (app.leave_type ?? '').toString().trim();
-            const normalizedLeaveType = leaveTypeValue.replace(/\s+/g, ' ').toLowerCase();
+            const normalizedLeaveType = leaveTypeValue
+                .toLowerCase()
+                .replace(/[-\s]+/g, ' ')
+                .trim();
             const isCashOut = normalizedLeaveType === 'cash out' || normalizedLeaveType === 'cashout';
 
             const hasUnpaid = Math.abs(unpaidHours) > 0.01;


### PR DESCRIPTION
## Summary
- replace punctuation and whitespace when normalizing leave types so hyphenated variants map to cash out

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9366ba0ac8325b9deb2d286268dc1