### PR TITLE
Ensure application action buttons stay on one line

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -564,7 +564,8 @@ tr:hover {
 .application-actions {
     display: flex;
     gap: 5px;
-    flex-wrap: wrap;
+    min-width: 190px;
+    flex-wrap: nowrap;
 }
 
 .application-actions button {


### PR DESCRIPTION
## Summary
- prevent the application actions buttons from wrapping by enforcing a minimum width and disabling flex wrapping

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94f6705dc832587c8e3db5ac4865b