### PR TITLE
Improve Application Status table responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -378,6 +378,18 @@ th, td {
     min-width: 120px;
 }
 
+/* Application Status table overrides */
+#application-status #applicationsTable {
+    min-width: 0;
+    white-space: normal;
+}
+
+#application-status #applicationsTable th,
+#application-status #applicationsTable td {
+    min-width: auto;
+    white-space: normal;
+}
+
 .unpaid-hours {
     color: var(--error-color);
     font-weight: 600;
@@ -564,8 +576,8 @@ tr:hover {
 .application-actions {
     display: flex;
     gap: 5px;
-    min-width: 190px;
-    flex-wrap: nowrap;
+    min-width: 140px;
+    flex-wrap: wrap;
 }
 
 .application-actions button {


### PR DESCRIPTION
## Summary
- remove the fixed min-width/nowrap styling on the Application Status table so its content can wrap within typical viewports
- allow the action button group to wrap and shrink, letting Approve/Reject stack on narrow layouts

## Testing
- Manual verification in the Application Status tab

------
https://chatgpt.com/codex/tasks/task_e_68d95666e93c8325b05a24aecc3e4b89