### PR TITLE
Adjust admin unpaid hours highlighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -2125,6 +2125,7 @@ async function loadAdminLeaveHistory(search = '') {
             const hasUnpaid = Math.abs(unpaidHours) > 0.01;
             const formattedLeaveType = formatLeaveTypeLabel(app.leave_type);
             const leaveLabel = hasUnpaid ? 'Unpaid Leave' : formattedLeaveType;
+            const unpaidHoursClassAttr = hasUnpaid ? ' class="unpaid-hours"' : '';
             const tr = document.createElement('tr');
             tr.innerHTML = `
                 <td>${app.employee_name}</td>
@@ -2132,7 +2133,7 @@ async function loadAdminLeaveHistory(search = '') {
                 <td>${app.start_date} ${app.start_time || ''} - ${app.end_date} ${app.end_time || ''}</td>
                 <td>${formatDurationFromHours(totalHours)}</td>
                 <td>${formatHours(paidHours)}</td>
-                <td class="unpaid-hours">${formatHours(unpaidHours)}</td>
+                <td${unpaidHoursClassAttr}>${formatHours(unpaidHours)}</td>
             `;
             tbody.appendChild(tr);
         });


### PR DESCRIPTION
## Summary
- conditionally apply the unpaid-hours styling in the admin history table only when unpaid time exists
- allow zero unpaid hours to inherit the default table text color

## Testing
- node - <<'NODE'
const hasUnpaidFalse = false;
const unpaidHoursClassAttrFalse = hasUnpaidFalse ? ' class="unpaid-hours"' : '';
console.log(`<td${unpaidHoursClassAttrFalse}>0.00 h</td>`);
const hasUnpaidTrue = true;
const unpaidHoursClassAttrTrue = hasUnpaidTrue ? ' class="unpaid-hours"' : '';
console.log(`<td${unpaidHoursClassAttrTrue}>1.50 h</td>`);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d9567871988325ae831a38542fc32a