### PR TITLE
Remove status column from admin applications table

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,6 @@
                                     <th>Start Date</th>
                                     <th>End Date</th>
                                     <th>Total Days</th>
-                                    <th>Status</th>
                                     <th>Actions</th>
                                 </tr>
                             </thead>

--- a/script.js
+++ b/script.js
@@ -1693,7 +1693,6 @@ async function loadLeaveApplications() {
                 <td>${app.start_date} ${app.start_time || ''}</td>
                 <td>${app.end_date} ${app.end_time || ''}</td>
                 <td>${formatDurationFromHours(getApplicationHours(app))}</td>
-                <td>${app.status}</td>
                 <td class="application-actions">
                     <button class="btn btn-success approve-btn">Approve</button>
                     <button class="btn btn-danger reject-btn">Reject</button>
@@ -1717,7 +1716,7 @@ async function loadLeaveApplications() {
 
         if (applications.length === 0) {
             const row = document.createElement('tr');
-            row.innerHTML = '<td colspan="8">No leave applications found</td>';
+            row.innerHTML = '<td colspan="7">No leave applications found</td>';
             tbody.appendChild(row);
         }
 


### PR DESCRIPTION
## Summary
- remove the Status column from the admin application status table
- update the application row template and empty-state colspan to match the new column count

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9566a77a8832598c0d92ef4f992ff