### PR TITLE
Ensure multi-day leave requests ignore time ranges

### DIFF
--- a/server.py
+++ b/server.py
@@ -305,6 +305,19 @@ def calculate_total_hours(
         except ValueError:
             return 0.0
 
+        if end_dt.date() < start_dt.date():
+            return 0.0
+
+        if end_dt.date() != start_dt.date():
+            legacy_days = _calculate_total_days_legacy(
+                start_date,
+                end_date,
+                start_day_type,
+                end_day_type,
+                holidays,
+            )
+            return round(legacy_days * WORK_HOURS_PER_DAY, 2)
+
         if end_dt <= start_dt:
             return 0.0
 

--- a/tests/test_hours_calculation.py
+++ b/tests/test_hours_calculation.py
@@ -20,3 +20,14 @@ def test_multi_day_request_is_capped_per_day():
     )
     assert math.isclose(days, 4.0, rel_tol=0, abs_tol=1e-6)
     assert hours == WORK_HOURS_PER_DAY * days
+
+
+def test_multi_day_request_ignores_time_offsets():
+    hours = calculate_total_hours(
+        "2025-09-29",
+        "2025-09-30",
+        start_time="15:00",
+        end_time="09:00",
+    )
+
+    assert math.isclose(hours, WORK_HOURS_PER_DAY * 2, rel_tol=0, abs_tol=1e-6)


### PR DESCRIPTION
## Summary
- disable time inputs on multi-day leave requests so duration calculations use full days
- short-circuit backend hour calculations to treat multi-day spans as whole workdays regardless of times
- add regression coverage for multi-day requests with conflicting time ranges

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d961568378832585d059895d66b9bf