### PR TITLE
Add working hours warning modal for leave validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,6 +485,22 @@
             </div>
         </div>
 
+        <!-- Working Hours Warning Modal -->
+        <div id="timeWarningModal" class="modal">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2>⚠️ Working Hours Reminder</h2>
+                    <button id="timeWarningClose" class="close-btn">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <p id="timeWarningMessage">Selected times must fall within working hours (06:30–15:00).</p>
+                </div>
+                <div class="modal-footer">
+                    <button id="timeWarningOk" type="button" class="btn-primary">OK</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Edit Employee Modal -->
         <div id="editModal" class="modal">
             <div class="modal-content">


### PR DESCRIPTION
## Summary
- add a working-hours warning modal to communicate the 06:30–15:00 schedule
- enrich single-day validation with error codes and surface them during live checks and submissions
- wire modal handlers alongside existing error handling utilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97d1beedc8325a95b507959b8c1b0