### PR TITLE
Align time input styling with date pickers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -100,7 +100,22 @@ header p {
     transition: border-color 0.2s ease;
 }
 
+.date-group input[type="time"] {
+    font-family: 'Times New Roman', serif;
+    padding: 12px;
+    border: 2px solid var(--border-color);
+    border-radius: var(--border-radius);
+    font-size: 1rem;
+    height: 48px;
+    transition: border-color 0.2s ease;
+}
+
 .date-group input[type="date"]:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.date-group input[type="time"]:focus {
     outline: none;
     border-color: var(--primary-color);
 }


### PR DESCRIPTION
## Summary
- style the leave request time inputs to use the serif typeface, padding, border, and height that match the date fields
- ensure the time inputs share the same focus border highlight as the date pickers for consistent feedback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d982da089c83258a94d9a81b1cde3a