### PR TITLE
Lock leave request time fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,13 +116,13 @@
                             <label for="startDate">Start Date:</label>
                             <input type="date" id="startDate" name="startDate" required>
                             <label for="startTime" class="time-label">Start Time:</label>
-                            <input type="time" id="startTime" name="startTime" step="60" required value="06:30">
+                            <input type="time" id="startTime" name="startTime" step="60" required value="06:30" readonly class="locked-time-input" data-default-time="06:30">
                         </div>
                         <div class="date-group">
                             <label for="endDate">End Date:</label>
                             <input type="date" id="endDate" name="endDate" required>
                             <label for="endTime" class="time-label">End Time:</label>
-                            <input type="time" id="endTime" name="endTime" step="60" required value="15:00">
+                            <input type="time" id="endTime" name="endTime" step="60" required value="15:00" readonly class="locked-time-input" data-default-time="15:00">
                         </div>
                     </div>
                     <div class="duration-display">

--- a/script.js
+++ b/script.js
@@ -403,6 +403,29 @@ const SERVICE_LENGTH_MAP = {
     '8+': 15
 };
 
+function initializeFixedTimeInputs() {
+    const inputs = [
+        document.getElementById('startTime'),
+        document.getElementById('endTime')
+    ];
+
+    inputs.forEach(input => {
+        if (!input) {
+            return;
+        }
+
+        const defaultTime = input.getAttribute('data-default-time') || input.value;
+        if (defaultTime) {
+            input.value = defaultTime;
+            input.dataset.defaultTime = defaultTime;
+        }
+
+        input.readOnly = true;
+        input.classList.add('locked-time-input');
+        input.setAttribute('aria-readonly', 'true');
+    });
+}
+
 // Handle login and app initialization
 document.addEventListener('DOMContentLoaded', function() {
     /* @tweakable whether to show debug messages during login flow initialization */
@@ -437,6 +460,7 @@ document.addEventListener('DOMContentLoaded', function() {
         console.log('- Script Loading Time:', new Date().toISOString());
     }
 
+    initializeFixedTimeInputs();
     initEntryButtons();
     restoreAuthenticationState();
     
@@ -1589,15 +1613,25 @@ function calculateLeaveDuration() {
     const isMultiDay = Boolean(startDate && endDate && startDate !== endDate);
 
     if (startTimeInput && endTimeInput) {
-        startTimeInput.disabled = isMultiDay;
-        endTimeInput.disabled = isMultiDay;
+        const defaultStartTime = startTimeInput.dataset.defaultTime || startTimeInput.getAttribute('data-default-time') || '06:30';
+        const defaultEndTime = endTimeInput.dataset.defaultTime || endTimeInput.getAttribute('data-default-time') || '15:00';
 
-        if (isMultiDay) {
-            if (startTimeInput.value) {
-                startTimeInput.value = '';
+        startTimeInput.readOnly = true;
+        endTimeInput.readOnly = true;
+        startTimeInput.required = !isMultiDay;
+        endTimeInput.required = !isMultiDay;
+
+        startTimeInput.classList.add('locked-time-input');
+        endTimeInput.classList.add('locked-time-input');
+        startTimeInput.setAttribute('aria-readonly', 'true');
+        endTimeInput.setAttribute('aria-readonly', 'true');
+
+        if (!isMultiDay) {
+            if (!startTimeInput.value) {
+                startTimeInput.value = defaultStartTime;
             }
-            if (endTimeInput.value) {
-                endTimeInput.value = '';
+            if (!endTimeInput.value) {
+                endTimeInput.value = defaultEndTime;
             }
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,18 @@ header p {
     transition: border-color 0.2s ease;
 }
 
+.locked-time-input {
+    background-color: #e2e8f0;
+    color: var(--text-secondary);
+    cursor: not-allowed;
+}
+
+.locked-time-input:focus {
+    outline: none;
+    border-color: var(--border-color);
+    box-shadow: none;
+}
+
 .date-group input[type="date"]:focus {
     outline: none;
     border-color: var(--primary-color);


### PR DESCRIPTION
## Summary
- make the leave request start and end time fields read-only with fixed default values
- initialize the form to retain the defaults for time calculations while keeping validation intact
- style the locked time pickers to visually indicate they are non-editable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d98770e3bc8325898557622b8fe616