### PR TITLE
Handle leave without pay fallback to unpaid hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,22 @@ ADMIN_EMAIL=admin@example.com
 Make sure to provide a real address in production so alerts reach the
 appropriate person.
 
+### Manual Verification
+
+#### Leave Without Pay History Display
+
+To confirm that leave without pay records appear under **Unpaid Hours** in the
+Leave History views:
+
+1. Start the development server as described in the Quick Start Guide.
+2. Create or update a leave application with the leave type set to
+   `Leave-Without-Pay` (hyphenated) or `Leave without pay` (spaced). Ensure it
+   spans at least one working day.
+3. Refresh the **Leave History** tab (or **Admin Leave History** for admin
+   users).
+4. Verify that the entry shows `0` under **Paid Hours** and the full duration of
+   the leave under **Unpaid Hours**.
+
+These steps confirm the UI correctly classifies leave without pay as unpaid
+even when no balance history record is associated with the application.
+

--- a/script.js
+++ b/script.js
@@ -2234,6 +2234,10 @@ async function loadLeaveHistory(employeeId, status = null) {
                 .toLowerCase()
                 .replace(/[-\s]+/g, ' ')
                 .trim();
+            if (normalizedLeaveType === 'leave without pay' && Math.abs(unpaidHours) <= 0.01) {
+                paidHours = 0;
+                unpaidHours = Number.isFinite(totalHours) ? totalHours : 0;
+            }
             const isCashOut = normalizedLeaveType === 'cash out' || normalizedLeaveType === 'cashout';
 
             const hasUnpaid = Math.abs(unpaidHours) > 0.01;
@@ -2335,6 +2339,10 @@ async function loadAdminLeaveHistory(search = '') {
                 .toLowerCase()
                 .replace(/[-\s]+/g, ' ')
                 .trim();
+            if (normalizedLeaveType === 'leave without pay' && Math.abs(unpaidHours) <= 0.01) {
+                paidHours = 0;
+                unpaidHours = Number.isFinite(totalHours) ? totalHours : 0;
+            }
             const isCashOut = normalizedLeaveType === 'cash out' || normalizedLeaveType === 'cashout';
 
             const hasUnpaid = Math.abs(unpaidHours) > 0.01;


### PR DESCRIPTION
## Summary
- ensure leave history views treat leave-without-pay entries as unpaid when no balance history exists
- document manual verification steps for confirming the unpaid hours display

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d98758066c8325a8c0276581792c86