### PR TITLE
Lock multi-day leave time pickers to default hours

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,13 +116,13 @@
                             <label for="startDate">Start Date:</label>
                             <input type="date" id="startDate" name="startDate" required>
                             <label for="startTime" class="time-label">Start Time:</label>
-                            <input type="time" id="startTime" name="startTime" step="60" required value="06:30">
+                            <input type="time" id="startTime" name="startTime" step="60" required value="06:30" data-default-time="06:30">
                         </div>
                         <div class="date-group">
                             <label for="endDate">End Date:</label>
                             <input type="date" id="endDate" name="endDate" required>
                             <label for="endTime" class="time-label">End Time:</label>
-                            <input type="time" id="endTime" name="endTime" step="60" required value="15:00">
+                            <input type="time" id="endTime" name="endTime" step="60" required value="15:00" data-default-time="15:00">
                         </div>
                     </div>
                     <div class="duration-display">

--- a/script.js
+++ b/script.js
@@ -1576,6 +1576,88 @@ function validateSingleDayTimeWindow(startDate, endDate, startTime, endTime) {
     };
 }
 
+function syncTimeInputLockState(startInput, endInput, isMultiDay) {
+    if (!startInput || !endInput) {
+        return;
+    }
+
+    const defaultStartTime = startInput.dataset.defaultTime || DEFAULT_WORKDAY_START_TIME;
+    const defaultEndTime = endInput.dataset.defaultTime || DEFAULT_WORKDAY_END_TIME;
+
+    if (startInput.dataset.originalRequired === undefined) {
+        startInput.dataset.originalRequired = startInput.required ? 'true' : 'false';
+    }
+    if (endInput.dataset.originalRequired === undefined) {
+        endInput.dataset.originalRequired = endInput.required ? 'true' : 'false';
+    }
+
+    if (!startInput.dataset.defaultTime) {
+        startInput.dataset.defaultTime = defaultStartTime;
+    }
+    if (!endInput.dataset.defaultTime) {
+        endInput.dataset.defaultTime = defaultEndTime;
+    }
+
+    if (isMultiDay) {
+        const wasLocked = startInput.dataset.locked === 'true';
+
+        if (!wasLocked) {
+            startInput.dataset.previousValue = startInput.value || '';
+            endInput.dataset.previousValue = endInput.value || '';
+        }
+
+        startInput.value = defaultStartTime;
+        endInput.value = defaultEndTime;
+
+        startInput.dataset.locked = 'true';
+        endInput.dataset.locked = 'true';
+
+        startInput.setAttribute('readonly', 'readonly');
+        endInput.setAttribute('readonly', 'readonly');
+        startInput.setAttribute('aria-readonly', 'true');
+        endInput.setAttribute('aria-readonly', 'true');
+        startInput.setAttribute('aria-disabled', 'true');
+        endInput.setAttribute('aria-disabled', 'true');
+
+        startInput.classList.add('time-input--locked');
+        endInput.classList.add('time-input--locked');
+
+        startInput.required = false;
+        endInput.required = false;
+    } else {
+        if (startInput.dataset.locked === 'true') {
+            if (startInput.dataset.previousValue !== undefined) {
+                startInput.value = startInput.dataset.previousValue || '';
+            }
+            if (endInput.dataset.previousValue !== undefined) {
+                endInput.value = endInput.dataset.previousValue || '';
+            }
+        }
+
+        startInput.dataset.locked = 'false';
+        endInput.dataset.locked = 'false';
+
+        delete startInput.dataset.previousValue;
+        delete endInput.dataset.previousValue;
+
+        startInput.removeAttribute('readonly');
+        endInput.removeAttribute('readonly');
+        startInput.removeAttribute('aria-readonly');
+        endInput.removeAttribute('aria-readonly');
+        startInput.removeAttribute('aria-disabled');
+        endInput.removeAttribute('aria-disabled');
+
+        startInput.classList.remove('time-input--locked');
+        endInput.classList.remove('time-input--locked');
+
+        startInput.required = startInput.dataset.originalRequired === 'true';
+        endInput.required = endInput.dataset.originalRequired === 'true';
+    }
+
+    startInput.disabled = isMultiDay;
+    endInput.disabled = isMultiDay;
+}
+
 function calculateLeaveDuration() {
     const startDateInput = document.getElementById('startDate');
     const endDateInput = document.getElementById('endDate');
@@ -1592,8 +1674,7 @@ function calculateLeaveDuration() {
     const isMultiDay = Boolean(startDate && endDate && startDate !== endDate);
 
     if (startTimeInput && endTimeInput) {
-        startTimeInput.disabled = isMultiDay;
-        endTimeInput.disabled = isMultiDay;
+        syncTimeInputLockState(startTimeInput, endTimeInput, isMultiDay);
     }
 
     if (!startDate || !endDate) {

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,22 @@ header p {
     border-color: var(--primary-color);
 }
 
+.date-group input[type="time"]:disabled,
+.date-group input[type="time"].time-input--locked {
+    background-color: #e2e8f0;
+    border-color: var(--border-color);
+    color: var(--text-secondary);
+    cursor: not-allowed;
+    opacity: 0.9;
+}
+
+.date-group input[type="time"]:disabled::-webkit-calendar-picker-indicator,
+.date-group input[type="time"].time-input--locked::-webkit-calendar-picker-indicator {
+    filter: grayscale(100%);
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 /* Duration display */
 .duration-display {
     text-align: center;


### PR DESCRIPTION
## Summary
- add default-time metadata to the vacation form inputs so scripted defaults stay in sync with the HTML
- lock the leave time pickers to the configured working hours on multi-day requests while restoring a user’s last single-day selection when unlocked
- style disabled/read-only time inputs so it’s clear when they cannot be edited

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d98cb98eac8325b4ecd41201605b86