### PR TITLE
Allow leave without pay when request exceeds privilege balance

### DIFF
--- a/tests/test_leave_without_pay_validation.py
+++ b/tests/test_leave_without_pay_validation.py
@@ -50,11 +50,22 @@ def _fetch_privilege_remaining_days(employee_id):
             conn.close()
 
 
-def test_leave_without_pay_rejected_when_privilege_remains(test_database):
+def test_leave_without_pay_rejected_when_request_within_privilege_balance(test_database):
     employee_id = _create_employee_with_privilege_balance()
 
     with pytest.raises(ValueError) as excinfo:
-        server.ensure_leave_without_pay_allowed(employee_id)
+        server.ensure_leave_without_pay_allowed(employee_id, requested_days=1)
 
     assert str(excinfo.value) == server.LEAVE_WITHOUT_PAY_PRIVILEGE_MESSAGE
     assert _fetch_privilege_remaining_days(employee_id) > 0
+
+
+def test_leave_without_pay_allowed_when_request_exceeds_privilege_balance(test_database):
+    employee_id = _create_employee_with_privilege_balance()
+    remaining = _fetch_privilege_remaining_days(employee_id)
+
+    # Request more than the remaining balance should be permitted
+    server.ensure_leave_without_pay_allowed(
+        employee_id,
+        requested_days=remaining + 1,
+    )


### PR DESCRIPTION
## Summary
- update the leave-without-pay guard to evaluate requested hours and days against the remaining privilege balance
- pass the server-side totals into the guard when validating leave applications
- extend leave-without-pay tests to cover both rejection and allowance scenarios

## Testing
- pytest tests/test_leave_without_pay_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d99b41d2a083258704675a50dc5012