### PR TITLE
Clarify Privilege Leave coverage messaging

### DIFF
--- a/tests/test_leave_history_unpaid_hours.py
+++ b/tests/test_leave_history_unpaid_hours.py
@@ -117,8 +117,15 @@ global.AbortController = class {
   abort() {}
 };
 global.FormData = class {
-  constructor() {}
+  constructor(form) {
+    this._data = form && typeof form.getFormData === 'function' ? form.getFormData() : {};
+  }
+
   append() {}
+
+  get(name) {
+    return this._data.hasOwnProperty(name) ? this._data[name] : null;
+  }
 };
 global.File = class {};
 global.navigator = { userAgent: 'node' };
@@ -204,3 +211,213 @@ backendRoom.collection = name => ({
     assert result.get("cellCount") >= 8
     assert result.get("leaveLabel") == "Unpaid Leave"
     assert result.get("unpaidCell") == "4.00 h"
+
+
+def test_privilege_leave_partial_request_triggers_alert_message():
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "script.js"
+
+    node_script = """
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync(__SCRIPT_PATH__, 'utf8');
+
+function createClassList() {
+  return { add() {}, remove() {} };
+}
+
+class Element {
+  constructor(tagName) {
+    this.tagName = tagName;
+    this.children = [];
+    this._innerHTML = '';
+    this.attributes = {};
+    this.classList = createClassList();
+    this.style = {};
+    this.dataset = {};
+    this.value = '';
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = value;
+    this.children = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+  }
+
+  querySelectorAll() {
+    return [];
+  }
+
+  querySelector() {
+    return null;
+  }
+
+  addEventListener() {}
+
+  removeEventListener() {}
+
+  setAttribute(name, value) {
+    this.attributes[name] = value;
+  }
+
+  get textContent() {
+    return this._innerHTML;
+  }
+
+  set textContent(value) {
+    this._innerHTML = value;
+  }
+}
+
+const alerts = [];
+
+const durationText = new Element('div');
+const startTime = new Element('input');
+startTime.value = '06:30';
+const endTime = new Element('input');
+endTime.value = '15:00';
+const startDate = new Element('input');
+startDate.value = '2024-01-01';
+const endDate = new Element('input');
+endDate.value = '2024-01-01';
+const loadingOverlay = new Element('div');
+const requestId = new Element('span');
+const successModal = new Element('div');
+successModal.classList = createClassList();
+
+const elementsById = {
+  durationText,
+  startTime,
+  endTime,
+  startDate,
+  endDate,
+  loadingOverlay,
+  requestId,
+  successModal,
+};
+
+const document = {
+  createElement: tag => new Element(tag),
+  getElementById: id => elementsById[id] || new Element('div'),
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  addEventListener: () => {},
+};
+
+document.body = new Element('body');
+
+const context = {
+  console: { log: () => {}, warn: () => {}, error: () => {} },
+  setTimeout,
+  clearTimeout,
+  document,
+  location: { href: 'http://localhost/', search: '' },
+  addEventListener: () => {},
+  alert: message => alerts.push(message),
+  confirm: () => true,
+  fetch: async () => ({ ok: true, json: async () => ({}), text: async () => '' }),
+  sessionStorage: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+  localStorage: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+  AbortController: class {
+    constructor() {
+      this.signal = {};
+    }
+
+    abort() {}
+  },
+  FormData: class {
+    constructor(form) {
+      this._data = form && typeof form.getFormData === 'function' ? form.getFormData() : {};
+    }
+
+    append() {}
+
+    get(name) {
+      return Object.prototype.hasOwnProperty.call(this._data, name) ? this._data[name] : null;
+    }
+  },
+  File: class {},
+  navigator: { userAgent: 'node' },
+};
+
+context.window = context;
+context.global = context;
+context.document = document;
+context.confirm = () => true;
+
+vm.createContext(context);
+vm.runInContext(code, context);
+
+context.room.collection = name => ({
+  create: async () => ({ application_id: 'APP-500' }),
+});
+
+context.calculateLeaveDuration = () => {};
+context.updateEmployeeInfo = async () => {};
+
+vm.runInContext('currentPrivilegeRemainingDays = 0.5; currentUser = { id: "emp-2", first_name: "Test", surname: "User" };', context);
+
+const leaveForm = {
+  getFormData() {
+    return {
+      leaveType: 'leave-without-pay',
+      startDate: '2024-01-01',
+      endDate: '2024-01-01',
+      startTime: '06:30',
+      endTime: '15:00',
+      reason: 'Testing partial coverage',
+    };
+  },
+  reset() {},
+};
+
+const event = {
+  preventDefault() {},
+  target: leaveForm,
+};
+
+(async () => {
+  await context.submitLeaveApplication(event);
+  const result = {
+    alertCount: alerts.length,
+    lastAlert: alerts.length ? alerts[alerts.length - 1] : null,
+  };
+  console.log(JSON.stringify(result));
+})().catch(error => {
+  console.log(JSON.stringify({ error: error.message }));
+  process.exit(1);
+});
+"""
+
+    node_script = node_script.replace("__SCRIPT_PATH__", json.dumps(str(script_path)))
+
+    completed = subprocess.run(
+        ["node", "-e", node_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = completed.stdout.strip()
+    assert output, completed.stderr
+
+    result = json.loads(output)
+    assert result.get("alertCount", 0) >= 1
+    message = result.get("lastAlert") or ""
+    assert "Privilege Leave will cover 4.00 h (0.50 d)" in message
+    assert "remaining 4.00 h (0.50 d)" in message


### PR DESCRIPTION
## Summary
- extend the Privilege Leave coverage helper to report paid and unpaid hours with a formatted warning message
- show detailed alerts when Leave Without Pay selections would consume remaining Privilege Leave during both type selection and submission
- expand the Node-based regression harness to confirm the alert content when a request exceeds the remaining Privilege Leave balance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9aac2b40c832585b8d7be686b15b7