### PR TITLE
Prevent leave without pay when privilege leave remains

### DIFF
--- a/script.js
+++ b/script.js
@@ -1800,22 +1800,11 @@ function calculateLeaveDuration() {
     }
 }
 
-function getAvailablePrivilegeLeaveHours() {
-    if (!Number.isFinite(currentPrivilegeRemainingDays) || currentPrivilegeRemainingDays <= 0) {
-        return null;
-    }
-    return currentPrivilegeRemainingDays * WORK_HOURS_PER_DAY;
-}
-
-function canCoverWithPrivilegeLeave(totalHours) {
-    const availableHours = getAvailablePrivilegeLeaveHours();
-    if (!Number.isFinite(totalHours) || totalHours <= 0 || !Number.isFinite(availableHours) || availableHours <= 0) {
-        return false;
-    }
-
-    // Allow for tiny floating point differences when comparing totals
-    const EPSILON = 0.001;
-    return totalHours <= availableHours + EPSILON;
+function canCoverWithPrivilegeLeave() {
+    return (
+        Number.isFinite(currentPrivilegeRemainingDays) &&
+        currentPrivilegeRemainingDays > 0
+    );
 }
 
 function computeRequestedTotalHours() {
@@ -1917,8 +1906,7 @@ function setupLeaveTypeHandling() {
     radios.forEach(radio => {
         radio.addEventListener('change', function() {
             if (this.checked && this.value === LEAVE_WITHOUT_PAY_VALUE) {
-                const requestedHours = computeRequestedTotalHours();
-                if (requestedHours !== null && canCoverWithPrivilegeLeave(requestedHours)) {
+                if (canCoverWithPrivilegeLeave()) {
                     showPrivilegeLeaveWarning();
                     revertLeaveWithoutPaySelection();
                     updateLeaveReasonState();
@@ -1985,7 +1973,7 @@ async function submitLeaveApplication(event, returnDate = null) {
         );
         const totalDays = totalHours > 0 ? Math.round((totalHours / WORK_HOURS_PER_DAY) * 10000) / 10000 : 0;
 
-        if (selectedLeaveType === LEAVE_WITHOUT_PAY_VALUE && canCoverWithPrivilegeLeave(totalHours)) {
+        if (selectedLeaveType === LEAVE_WITHOUT_PAY_VALUE && canCoverWithPrivilegeLeave()) {
             hideLoading();
             showPrivilegeLeaveWarning();
             revertLeaveWithoutPaySelection();

--- a/server.py
+++ b/server.py
@@ -309,49 +309,7 @@ def ensure_leave_without_pay_allowed(
 
     tolerance = 1e-6
 
-    remaining_hours = (
-        remaining_days * WORK_HOURS_PER_DAY if WORK_HOURS_PER_DAY else None
-    )
-
-    requested_days_value = None
-    if requested_days is not None:
-        try:
-            requested_days_value = float(requested_days)
-        except (TypeError, ValueError):
-            requested_days_value = None
-
-    requested_hours_value = None
-    if requested_hours is not None:
-        try:
-            requested_hours_value = float(requested_hours)
-        except (TypeError, ValueError):
-            requested_hours_value = None
-
-    if requested_days_value is None and requested_hours_value is not None and WORK_HOURS_PER_DAY:
-        requested_days_value = requested_hours_value / WORK_HOURS_PER_DAY
-
-    if requested_hours_value is None and requested_days_value is not None and WORK_HOURS_PER_DAY:
-        requested_hours_value = requested_days_value * WORK_HOURS_PER_DAY
-
-    if (
-        requested_hours_value is not None
-        and remaining_hours is not None
-        and requested_hours_value <= (remaining_hours + tolerance)
-    ):
-        raise ValueError(LEAVE_WITHOUT_PAY_PRIVILEGE_MESSAGE)
-
-    if (
-        requested_hours_value is None
-        and requested_days_value is not None
-        and requested_days_value <= (remaining_days + tolerance)
-    ):
-        raise ValueError(LEAVE_WITHOUT_PAY_PRIVILEGE_MESSAGE)
-
-    if (
-        requested_days_value is None
-        and requested_hours_value is None
-        and remaining_days > tolerance
-    ):
+    if remaining_days > tolerance:
         raise ValueError(LEAVE_WITHOUT_PAY_PRIVILEGE_MESSAGE)
 
 def _calculate_total_days_legacy(

--- a/tests/test_leave_without_pay_validation.py
+++ b/tests/test_leave_without_pay_validation.py
@@ -61,15 +61,19 @@ def test_leave_without_pay_rejected_when_request_within_privilege_balance(test_d
     assert _fetch_privilege_remaining_days(employee_id) > 0
 
 
-def test_leave_without_pay_allowed_when_request_exceeds_privilege_balance(test_database):
+def test_leave_without_pay_rejected_when_request_exceeds_privilege_balance(test_database):
     employee_id = _create_employee_with_privilege_balance()
     remaining = _fetch_privilege_remaining_days(employee_id)
 
-    # Request more than the remaining balance should be permitted
-    server.ensure_leave_without_pay_allowed(
-        employee_id,
-        requested_days=remaining + 1,
-    )
+    # Requesting more than the remaining balance must still be rejected when
+    # any privilege leave remains.
+    with pytest.raises(ValueError) as excinfo:
+        server.ensure_leave_without_pay_allowed(
+            employee_id,
+            requested_days=remaining + 1,
+        )
+
+    assert str(excinfo.value) == server.LEAVE_WITHOUT_PAY_PRIVILEGE_MESSAGE
 
 
 def test_leave_without_pay_uses_current_year_balance(test_database):


### PR DESCRIPTION
## Summary
- prevent the UI from allowing leave without pay when any privilege leave remains
- simplify the server-side validation to reject leave without pay whenever the privilege balance is positive
- update the leave without pay validation tests to cover the stricter rule

## Testing
- pytest tests/test_leave_without_pay_validation.py


------
https://chatgpt.com/codex/tasks/task_e_68d9c957efe48325a3885716ef78c50d