### PR TITLE
Allow adjusting privilege leave allocations

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="annualLeave">Privilege Leave (PL) (days)</label>
-                                <input type="number" id="annualLeave" name="annualLeave" min="0" max="45" required readonly>
+                                <input type="number" id="annualLeave" name="annualLeave" min="0" max="45" required>
                             </div>
                             <div class="form-group">
                                 <label for="sickLeave">Sick Leave (SL) (days)</label>
@@ -527,7 +527,7 @@
                     <div class="form-row">
                         <div class="form-group">
                             <label for="editAnnualLeave">Privilege Leave (PL) (days)</label>
-                            <input type="number" id="editAnnualLeave" name="editAnnualLeave" min="0" max="45" required readonly>
+                            <input type="number" id="editAnnualLeave" name="editAnnualLeave" min="0" max="45" required>
                         </div>
                         <div class="form-group">
                             <label for="editServiceLength">Service Length</label>


### PR DESCRIPTION
## Summary
- remove the readonly restriction from the privilege leave inputs on the add and edit employee forms so the values can be adjusted like sick leave

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68db441afbd8832580f04bf24333916d