### PR TITLE
Enforce admin credentials via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 ADMIN_EMAIL=admin@example.com
+# Administrator login. Replace with a unique username and a strong, randomly
+# generated password (for example: `python -c "import secrets; print(secrets.token_urlsafe(32))"`).
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=replace-with-a-strong-secret
 # Optional: comma-separated list of admin emails to notify on approvals.
 # Falls back to ADMIN_EMAIL when unset.
 ADMIN_APPROVE_EMAIL=admin@example.com,backup-admin@example.com

--- a/README.md
+++ b/README.md
@@ -45,20 +45,27 @@ A comprehensive web-based leave management system designed for small to medium o
    SMTP_PASSWORD = "your-app-password"     # Your Gmail App Password
    ```
 
-#### Administrator Email
+#### Administrator Credentials
 
-The server requires an email address for the administrator so notifications can
-be delivered when employees submit leave requests. Set this via an
-`ADMIN_EMAIL` environment variable. The application will read variables from a
+The server requires dedicated credentials for the administrator interface. Set
+the following environment variables before launching the application:
+
+- `ADMIN_EMAIL`: where approval and notification emails should be delivered.
+- `ADMIN_USERNAME`: the username administrators will use to sign in.
+- `ADMIN_PASSWORD`: a strong password for the administrator account.
+
+The application will read these values from the surrounding environment or a
 local `.env` file if present:
 
 ```bash
 # .env
 ADMIN_EMAIL=admin@example.com
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
 ```
 
-Make sure to provide a real address in production so alerts reach the
-appropriate person.
+Make sure to generate unique, high-entropy secrets for production environments
+and distribute them through your organisation's secret management tooling.
 
 ### Manual Verification
 

--- a/bash
+++ b/bash
@@ -1,2 +1,18 @@
-python server.py 8080
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load local development overrides if present. Production deployments should
+# provide secrets via the environment or a dedicated secret manager.
+if [[ -f .env ]]; then
+  # shellcheck disable=SC1091
+  set -o allexport
+  source .env
+  set +o allexport
+fi
+
+: "${ADMIN_EMAIL:?ADMIN_EMAIL environment variable is required}"
+: "${ADMIN_USERNAME:?ADMIN_USERNAME environment variable is required}"
+: "${ADMIN_PASSWORD:?ADMIN_PASSWORD environment variable is required}"
+
+exec python server.py "${1:-8080}"
 

--- a/server.py
+++ b/server.py
@@ -86,9 +86,23 @@ EARLIEST_LEAVE_TIME = datetime.strptime("06:30", "%H:%M").time()
 LATEST_LEAVE_TIME = datetime.strptime("15:00", "%H:%M").time()
 
 # @tweakable server configuration
-ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "mgllanos@gmail.com")
-if not ADMIN_EMAIL:
-    raise RuntimeError("ADMIN_EMAIL environment variable is required")
+
+
+def _require_env(name: str) -> str:
+    """Return the value of ``name`` from the environment, failing fast when absent."""
+
+    value = os.getenv(name)
+    if value is None:
+        raise RuntimeError(f"{name} environment variable is required")
+    if not value.strip():
+        raise RuntimeError(f"{name} environment variable must not be empty")
+    # Preserve any intentional whitespace for secrets while normalising identifiers.
+    if name.endswith("_PASSWORD"):
+        return value
+    return value.strip()
+
+
+ADMIN_EMAIL = _require_env("ADMIN_EMAIL")
 
 
 def _parse_email_list(raw_value):
@@ -102,8 +116,8 @@ def _parse_email_list(raw_value):
 ADMIN_APPROVE_EMAILS = _parse_email_list(os.getenv("ADMIN_APPROVE_EMAIL"))
 if not ADMIN_APPROVE_EMAILS:
     ADMIN_APPROVE_EMAILS = _parse_email_list(ADMIN_EMAIL) or [ADMIN_EMAIL]
-ADMIN_USERNAME = "admin"
-ADMIN_PASSWORD = "admin123"
+ADMIN_USERNAME = _require_env("ADMIN_USERNAME")
+ADMIN_PASSWORD = _require_env("ADMIN_PASSWORD")
 
 # @tweakable employee management configuration - define missing constants
 AUTO_CREATE_BALANCE_RECORDS = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,14 @@ import os
 import sys
 
 
+# Provide default administrator credentials required by ``server`` during
+# import. Test environments should override these with secure values if
+# necessary.
+os.environ.setdefault("ADMIN_EMAIL", "admin@example.com")
+os.environ.setdefault("ADMIN_USERNAME", "test-admin")
+os.environ.setdefault("ADMIN_PASSWORD", "test-admin-password")
+
+
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- require the admin email, username, and password to be supplied via environment variables during server startup
- document the required administrator credentials and highlight generating strong secrets in the README and `.env` example
- update the startup script and test harness to load or supply the required environment variables before running the server

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df4453d0ec83259338ea9298333e97