### PR TITLE
Require environment SMTP configuration for email service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,9 @@ ADMIN_EMAIL=admin@example.com
 # Optional: comma-separated list of admin emails to notify on approvals.
 # Falls back to ADMIN_EMAIL when unset.
 ADMIN_APPROVE_EMAIL=admin@example.com,backup-admin@example.com
+
+# SMTP credentials required for outbound email notifications.
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=notifications@example.com
+SMTP_PASSWORD=replace-with-app-password

--- a/README.md
+++ b/README.md
@@ -37,13 +37,20 @@ A comprehensive web-based leave management system designed for small to medium o
 ### Step 2: Configuration
 
 #### Email Notifications (Optional but Recommended)
-1. Configure your email credentials in `services/email_service.py` or via
-   environment variables.
-2. Replace the default credentials:
-   ```python
-   SMTP_USERNAME = "your-email@gmail.com"  # Your Gmail address
-   SMTP_PASSWORD = "your-app-password"     # Your Gmail App Password
+1. Provide SMTP credentials via environment variables. Email delivery will
+   fail fast during startup if these values are missing.
+2. Create or update a `.env` file (or the deployment environment) with the
+   required keys:
+   ```bash
+   # .env
+   SMTP_SERVER=smtp.example.com
+   SMTP_PORT=587
+   SMTP_USERNAME=notifications@example.com
+   SMTP_PASSWORD=replace-with-app-password
    ```
+3. The bundled `server.py` loads the `.env` file during startup before importing
+   the email service, ensuring the credentials are available both in
+   development and production deployments that follow the same pattern.
 
 #### Administrator Email
 

--- a/server.py
+++ b/server.py
@@ -10,6 +10,22 @@ import sqlite3
 from datetime import datetime, timedelta  # @tweakable include timedelta for date calculations
 from http.cookies import SimpleCookie
 
+
+def _load_env(path: str = ".env") -> None:
+    """Populate ``os.environ`` from a ``.env`` file if it exists."""
+
+    if os.path.exists(path):
+        with open(path) as env_file:
+            for raw_line in env_file:
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, _, value = line.partition("=")
+                os.environ.setdefault(key.strip(), value.strip())
+
+
+_load_env()
+
 # Import service modules
 from services.database_service import init_database, get_db_connection, db_lock
 from services.employee_service import create_employee, update_employee, delete_employee, get_employees, get_employee_by_email
@@ -47,20 +63,6 @@ except Exception as log_err:  # noqa: BLE001 - broad exception to keep server ru
         "Falling back to stderr logging because server.log could not be opened: %s",
         log_err,
     )
-
-# Load environment variables from a .env file if present
-def _load_env(path: str = ".env") -> None:
-    """Populate ``os.environ`` from a ``.env`` file if it exists."""
-    if os.path.exists(path):
-        with open(path) as env_file:
-            for raw_line in env_file:
-                line = raw_line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                key, _, value = line.partition("=")
-                os.environ.setdefault(key.strip(), value.strip())
-
-_load_env()
 
 # Configure logging
 LOG_FILE = os.getenv("LOG_FILE", "server.log")

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -13,13 +13,27 @@ from datetime import datetime, timedelta
 from email.message import EmailMessage
 
 
-# Default configuration can be provided via environment variables. These values
-# are only used if explicit settings are not supplied when calling
-# ``send_notification_email``.
-SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.gmail.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
-SMTP_USERNAME = os.getenv("SMTP_USERNAME", "qtaskvacation@gmail.com")
-SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "bicg llyb myff kigu")
+def _require_env(key: str) -> str:
+    """Return the value of ``key`` from the environment or raise an error."""
+
+    value = os.getenv(key)
+    if value is None or value.strip() == "":
+        raise RuntimeError(
+            f"{key} environment variable is required for SMTP email delivery"
+        )
+    return value
+
+
+# Configuration must be supplied via the environment to avoid shipping secrets
+# in source control. A clear error is raised during application startup when the
+# variables are missing so deployments can fail fast.
+SMTP_SERVER = _require_env("SMTP_SERVER")
+try:
+    SMTP_PORT = int(_require_env("SMTP_PORT"))
+except ValueError as exc:  # pragma: no cover - defensive
+    raise RuntimeError("SMTP_PORT must be an integer") from exc
+SMTP_USERNAME = _require_env("SMTP_USERNAME")
+SMTP_PASSWORD = _require_env("SMTP_PASSWORD")
 
 
 def generate_ics_content(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,11 @@ import sys
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
+
+for key, value in (
+    ("SMTP_SERVER", "smtp.test"),
+    ("SMTP_PORT", "2525"),
+    ("SMTP_USERNAME", "user@test"),
+    ("SMTP_PASSWORD", "secret"),
+):
+    os.environ.setdefault(key, value)

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,3 +1,13 @@
+import os
+
+for key, value in (
+    ("SMTP_SERVER", "smtp.test"),
+    ("SMTP_PORT", "2525"),
+    ("SMTP_USERNAME", "user@test"),
+    ("SMTP_PASSWORD", "secret"),
+):
+    os.environ.setdefault(key, value)
+
 from services import email_service
 
 


### PR DESCRIPTION
## Summary
- require SMTP configuration to be supplied through environment variables and fail fast when missing
- ensure the server loads .env values before importing the email service and document the new configuration requirements
- provide placeholder SMTP settings for local setup and update tests to seed credentials during collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df4451c6e8832582bbbb7ab245f299