### PR TITLE
Ensure admin approval notifications use OOO subject

### DIFF
--- a/server.py
+++ b/server.py
@@ -1217,7 +1217,10 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                 status_word = 'approved' if new_status == 'Approved' else 'rejected'
                                 return_date = next_workday(end_date, holidays)
 
-                                admin_subject = f"Leave application {status_word}: {employee_name}"
+                                if new_status == 'Approved':
+                                    admin_subject = f"{employee_name} - OOO"
+                                else:
+                                    admin_subject = f"Leave application {status_word}: {employee_name}"
 
                                 admin_body = (
                                     f"Leave request for {employee_name} (Application ID: {app_id}) has been {status_word}.\n\n"

--- a/tests/test_server_approval_ics.py
+++ b/tests/test_server_approval_ics.py
@@ -175,6 +175,7 @@ def test_all_admin_recipients_receive_approval_notification(monkeypatch):
     assert {call["to"] for call in admin_calls} == set(admin_recipients)
     for call in admin_calls:
         assert call["ics"] == ics_payload
+        assert call["subject"] == "Alice Smith - OOO"
 
     assert len(employee_calls) == 1
     assert employee_calls[0]["ics"] is None


### PR DESCRIPTION
## Summary
- ensure admin approval notification emails use the approved "OOO" subject format for approved requests
- expand the approval notification test to validate the subject for all admin recipients

## Testing
- pytest tests/test_server_approval_ics.py::test_all_admin_recipients_receive_approval_notification


------
https://chatgpt.com/codex/tasks/task_e_68e1ead5037c83258a24435f7a53fac0