### PR TITLE
Set approved admin subject for approvals

### DIFF
--- a/server.py
+++ b/server.py
@@ -1217,7 +1217,10 @@ class LeaveManagementHandler(http.server.SimpleHTTPRequestHandler):
                                 status_word = 'approved' if new_status == 'Approved' else 'rejected'
                                 return_date = next_workday(end_date, holidays)
 
-                                admin_subject = f"Leave application {status_word}: {employee_name}"
+                                if new_status == 'Approved':
+                                    admin_subject = f"{employee_name} - OOO"
+                                else:
+                                    admin_subject = f"Leave application {status_word}: {employee_name}"
 
                                 admin_body = (
                                     f"Leave request for {employee_name} (Application ID: {app_id}) has been {status_word}.\n\n"

--- a/tests/test_server_approval_ics.py
+++ b/tests/test_server_approval_ics.py
@@ -175,6 +175,7 @@ def test_all_admin_recipients_receive_approval_notification(monkeypatch):
     assert {call["to"] for call in admin_calls} == set(admin_recipients)
     for call in admin_calls:
         assert call["ics"] == ics_payload
+        assert call["subject"] == "Alice Smith - OOO"
 
     assert len(employee_calls) == 1
     assert employee_calls[0]["ics"] is None


### PR DESCRIPTION
## Summary
- update the admin email subject for approved leave applications to use the "employee - OOO" format
- extend approval notification test coverage to assert the admin subject uses the new format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1ead071a883259efe3ba9b6db252e