### PR TITLE
Replace privilege leave terminology with vacation leave

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
                 <h3>📊 Available Leave Balance</h3>
                 <div class="balance-row">
                     <div class="balance-item privilege-leave">
-                        <span class="balance-label">🏖️ Privilege Leave (PL):</span>
+                        <span class="balance-label">🏖️ Vacation Leave (VL):</span>
                         <span class="balance-value" id="privilegeLeaveBalance">-- days</span>
                     </div>
                     <div class="balance-item sick-leave">
@@ -282,7 +282,7 @@
                                 </select>
                             </div>
                             <div class="form-group">
-                                <label for="annualLeave">Privilege Leave (PL) (days)</label>
+                                <label for="annualLeave">Vacation Leave (VL) (days)</label>
                                 <input type="number" id="annualLeave" name="annualLeave" min="0" max="45" required>
                             </div>
                             <div class="form-group">
@@ -306,7 +306,7 @@
                                 <tr>
                                     <th>Employee Name</th>
                                     <th>Email Address</th>
-                                    <th>Privilege Leave (PL)</th>
+                                    <th>Vacation Leave (VL)</th>
                                     <th>Sick Leave (SL)</th>
                                     <th>Actions</th>
                                 </tr>
@@ -353,9 +353,9 @@
                             <thead>
                                 <tr>
                                     <th>Employee</th>
-                                    <th>Privilege Allocated</th>
-                                    <th>Privilege Used</th>
-                                    <th>Privilege Remaining</th>
+                                    <th>Vacation Allocated</th>
+                                    <th>Vacation Used</th>
+                                    <th>Vacation Remaining</th>
                                     <th>Sick Allocated</th>
                                     <th>Sick Used</th>
                                     <th>Sick Remaining</th>
@@ -526,7 +526,7 @@
                     
                     <div class="form-row">
                         <div class="form-group">
-                            <label for="editAnnualLeave">Privilege Leave (PL) (days)</label>
+                            <label for="editAnnualLeave">Vacation Leave (VL) (days)</label>
                             <input type="number" id="editAnnualLeave" name="editAnnualLeave" min="0" max="45" required>
                         </div>
                         <div class="form-group">
@@ -546,9 +546,9 @@
                     
                     <div class="form-row">
                         <div class="form-group">
-                            <label for="editRemainingPrivilege">Privilege Remaining (days)</label>
+                            <label for="editRemainingPrivilege">Vacation Remaining (days)</label>
                             <input type="number" id="editRemainingPrivilege" name="editRemainingPrivilege" min="0" step="0.5" required>
-                            <small class="form-help">@tweakable Current unused privilege leave days</small>
+                            <small class="form-help">@tweakable Current unused vacation leave days</small>
                         </div>
                         <div class="form-group">
                             <label for="editRemainingSick">Sick Remaining (days)</label>

--- a/server.py
+++ b/server.py
@@ -101,7 +101,7 @@ logging.basicConfig(
 # Default sick leave allocation
 DEFAULT_SICK_LEAVE = 5
 
-LEAVE_WITHOUT_PAY_PRIVILEGE_MESSAGE = "Please use your remaining Privilege Leave before requesting Leave Without Pay."
+LEAVE_WITHOUT_PAY_VACATION_MESSAGE = "Please use your remaining Vacation Leave (VL) before requesting Leave Without Pay."
 
 # Standard number of working hours in a full day. Used to translate between
 # hourly requests and legacy day-based balance tracking.
@@ -234,7 +234,7 @@ def compute_cash_out_request(data, total_days, total_hours):
 
 
 def ensure_cash_out_balance(employee_id, requested_days, requested_hours, preferred_unit='days'):
-    """Ensure the employee has enough Privilege Leave for a cash-out request."""
+    """Ensure the employee has enough Vacation Leave (VL) for a cash-out request."""
 
     if not employee_id:
         raise ValueError("Employee ID is required for cash-out requests.")
@@ -279,13 +279,13 @@ def ensure_cash_out_balance(employee_id, requested_days, requested_hours, prefer
     if preferred_unit == 'hours' and WORK_HOURS_PER_DAY:
         if requested_hours > remaining_hours + tolerance:
             raise ValueError(
-                f"Cash-out request of {requested_hours:.2f} hours exceeds remaining Privilege Leave "
+                f"Cash-out request of {requested_hours:.2f} hours exceeds remaining Vacation Leave (VL) "
                 f"({remaining_hours:.2f} hours)."
             )
     else:
         if requested_days > remaining_days + tolerance:
             raise ValueError(
-                f"Cash-out request of {requested_days:.2f} days exceeds remaining Privilege Leave "
+                f"Cash-out request of {requested_days:.2f} days exceeds remaining Vacation Leave (VL) "
                 f"({remaining_days:.2f} days)."
             )
 
@@ -297,9 +297,9 @@ def ensure_leave_without_pay_allowed(
     requested_days=None,
     requested_hours=None,
 ):
-    """Prevent Leave Without Pay when Privilege Leave remains.
+    """Prevent Leave Without Pay when Vacation Leave (VL) remains.
 
-    The privilege balance for the current calendar year is preferred when
+    The vacation balance for the current calendar year is preferred when
     multiple yearly records exist. If the current year's record is missing we
     fall back to the most recent year to ensure the validation tracks the
     latest balances in the database.
@@ -362,7 +362,7 @@ def ensure_leave_without_pay_allowed(
     tolerance = 1e-6
 
     if remaining_days > tolerance:
-        raise ValueError(LEAVE_WITHOUT_PAY_PRIVILEGE_MESSAGE)
+        raise ValueError(LEAVE_WITHOUT_PAY_VACATION_MESSAGE)
 
 def _calculate_total_days_legacy(
     start_date,

--- a/tests/test_cash_out_validations.py
+++ b/tests/test_cash_out_validations.py
@@ -35,7 +35,7 @@ def _create_employee_with_balance(annual_leave):
     return employee_id
 
 
-def _fetch_remaining_privilege_days(employee_id):
+def _fetch_remaining_vacation_days(employee_id):
     with db_lock:
         conn = get_db_connection()
         try:
@@ -56,8 +56,8 @@ def test_cash_out_submission_rejected_when_request_exceeds_balance(test_database
     with pytest.raises(ValueError) as excinfo:
         server.ensure_cash_out_balance(employee_id, requested_days=2.0, requested_hours=16.0, preferred_unit='days')
 
-    assert 'exceeds remaining Privilege Leave' in str(excinfo.value)
-    assert pytest.approx(_fetch_remaining_privilege_days(employee_id)) == 1.0
+    assert 'exceeds remaining Vacation Leave (VL)' in str(excinfo.value)
+    assert pytest.approx(_fetch_remaining_vacation_days(employee_id)) == 1.0
 
 
 def test_cash_out_approval_does_not_allow_negative_balance(test_database):
@@ -101,5 +101,5 @@ def test_cash_out_approval_does_not_allow_negative_balance(test_database):
     with pytest.raises(ValueError) as excinfo:
         balance_manager.process_leave_application_balance(application_id, 'Approved', changed_by='TEST')
 
-    assert 'Insufficient privilege leave balance' in str(excinfo.value)
-    assert pytest.approx(_fetch_remaining_privilege_days(employee_id)) == 1.0
+    assert 'Insufficient Vacation Leave (VL) balance' in str(excinfo.value)
+    assert pytest.approx(_fetch_remaining_vacation_days(employee_id)) == 1.0

--- a/tests/test_leave_history_unpaid_hours.py
+++ b/tests/test_leave_history_unpaid_hours.py
@@ -163,7 +163,7 @@ window.eval(`
   updateLeaveBalanceDisplay = async function() {
     const container = document.getElementById('leaveBalanceDisplay');
     if (!currentUser || !container) {
-      currentPrivilegeRemainingDays = 0;
+      currentVacationRemainingDays = 0;
       return;
     }
     const balances = __testBalances;
@@ -199,7 +199,7 @@ window.eval(`
     const parsedPrivilege = priv && priv.remaining_days != null
       ? Number.parseFloat(priv.remaining_days)
       : 0;
-    currentPrivilegeRemainingDays = Number.isFinite(parsedPrivilege) ? parsedPrivilege : 0;
+    currentVacationRemainingDays = Number.isFinite(parsedPrivilege) ? parsedPrivilege : 0;
 
     const privEl = document.getElementById('privilegeLeaveBalance');
     const sickEl = document.getElementById('sickLeaveBalance');

--- a/tests/test_privilege_leave_warning_behavior.py
+++ b/tests/test_privilege_leave_warning_behavior.py
@@ -171,9 +171,9 @@ global.FormData = class {
 
 eval(code);
 
-window.eval('(() => { window.__setPrivilegeRemaining = value => { currentPrivilegeRemainingDays = value; }; window.__setCurrentUser = value => { currentUser = value; }; window.__getCurrentUser = () => currentUser; window.__setAck = value => { privilegeLeaveWarningAcknowledged = value; }; window.__readAck = () => privilegeLeaveWarningAcknowledged; window.__setLastValidLeaveTypeValue = value => { lastValidLeaveTypeValue = value; }; })();');
+window.eval('(() => { window.__setVacationRemaining = value => { currentVacationRemainingDays = value; }; window.__setCurrentUser = value => { currentUser = value; }; window.__getCurrentUser = () => currentUser; window.__setAck = value => { vacationLeaveWarningAcknowledged = value; }; window.__readAck = () => vacationLeaveWarningAcknowledged; window.__setLastValidLeaveTypeValue = value => { lastValidLeaveTypeValue = value; }; })();');
 
-window.__setPrivilegeRemaining(5);
+window.__setVacationRemaining(5);
 window.__setLastValidLeaveTypeValue('vacation-leave');
 window.__setAck(false);
 window.__setCurrentUser({ id: 'emp-1', first_name: 'Test', surname: 'User' });
@@ -377,6 +377,10 @@ runSequence().then(results => {
     confirmations = result["confirmations"]
     assert len(confirmations) == 3
     warning_message = confirmations[0]
+    expected_warning = (
+        'You still have available Vacation Leave (VL); continuing will consume your available leave first.'
+    )
+    assert warning_message == expected_warning
     assert all(message == warning_message for message in confirmations)
 
     first_selection = result["firstSelection"]
@@ -401,7 +405,7 @@ runSequence().then(results => {
     assert submit_attempt["lastPayload"]["data"]["leave_type"] != LEAVE_WITHOUT_PAY_VALUE
     assert submit_attempt["lastPayload"]["data"]["selected_reasons"] == ["vacation-leave"]
     expected_notice = (
-        "You still have Privilege Leave remaining. Your request has been updated to use Privilege Leave before unpaid leave."
+        "You still have Vacation Leave (VL) remaining. Your request has been updated to use Vacation Leave before unpaid leave."
     )
     assert submit_attempt["durationMessage"] == expected_notice
 


### PR DESCRIPTION
## Summary
- rename all UI labels to display "Vacation Leave (VL)" instead of "Privilege Leave (PL)"
- update front-end validation messages and helpers to reference Vacation Leave, including new warning copy
- align backend messages and constants plus test expectations with the Vacation Leave terminology

## Testing
- pytest tests/test_cash_out_validations.py tests/test_leave_without_pay_validation.py tests/test_privilege_leave_warning_behavior.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ef3546188325a2a3d5b554de90d5