### PR TITLE
Remove auto-created calendar invites on leave approval

### DIFF
--- a/server.py
+++ b/server.py
@@ -67,7 +67,6 @@ from services.balance_manager import (
 )
 from services.email_service import (
     send_notification_email,
-    generate_ics_content,
     SMTP_SERVER,
     SMTP_PORT,
     SMTP_USERNAME,
@@ -1310,27 +1309,6 @@ Management
 """
 
                                 ics_content = None
-                                if new_status == 'Approved':
-                                    ics_content = generate_ics_content(
-                                        start_date,
-                                        end_date,
-                                        summary=f"{employee_name} - OOO",
-                                        description=(
-                                            f"Approved leave from {start_date} {start_time or ''} to {end_date} {end_time or ''} "
-                                            f"({total_hours} hours / {total_days} days)"
-                                        ),
-                                        start_time=start_time,
-                                        end_time=end_time,
-                                        uid=f"{app_id}@leave-management-system",
-                                        organizer_email=os.getenv('SMTP_USERNAME'),
-                                        organizer_name='Leave Management System',
-                                        attendee_email=employee_email,
-                                        attendee_name=employee_name,
-                                        sequence=0,
-                                        status='CONFIRMED',
-                                        force_utc=False,
-                                        floating_time=True,
-                                    )
 
                                 admin_recipients = ADMIN_APPROVE_EMAILS or []
                                 if admin_recipients:


### PR DESCRIPTION
### Motivation
- The application should stop auto-generating and attaching calendar invites when a leave request is approved to avoid sending ICS files automatically.

### Description
- Removed the `generate_ics_content` usage from the approval workflow so `ics_content` remains `None` for approval notifications and no ICS is attached to emails. 
- Removed the `generate_ics_content` import from `server.py` since it is no longer invoked in the approval path.
- Updated tests in `tests/test_server_approval_ics.py` to reflect the new behavior by asserting that `generate_ics_content` is not called and that admin and employee notification email payloads contain `ics=None`.

### Testing
- Ran `pytest -q tests/test_server_approval_ics.py` and observed `3 passed` indicating the approval notification behavior and updated assertions succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd807dba88325aa7f7f43522bc758)