### PR TITLE
Support 12-hour AM/PM times in time parsing to fix return-date prompt

### DIFF
--- a/script.js
+++ b/script.js
@@ -1700,7 +1700,33 @@ function parseTimeToMinutes(timeValue) {
         return null;
     }
 
-    const [hoursPart, minutesPart] = timeValue.split(':');
+    const normalizedTime = timeValue.trim();
+    if (!normalizedTime) {
+        return null;
+    }
+
+    const twelveHourMatch = normalizedTime.match(/^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$/);
+    if (twelveHourMatch) {
+        const hourComponent = Number.parseInt(twelveHourMatch[1], 10);
+        const minuteComponent = Number.parseInt(twelveHourMatch[2], 10);
+        const meridiem = twelveHourMatch[3].toUpperCase();
+
+        if (
+            !Number.isInteger(hourComponent) ||
+            !Number.isInteger(minuteComponent) ||
+            hourComponent < 1 ||
+            hourComponent > 12 ||
+            minuteComponent < 0 ||
+            minuteComponent >= 60
+        ) {
+            return null;
+        }
+
+        const normalizedHours = hourComponent % 12 + (meridiem === 'PM' ? 12 : 0);
+        return normalizedHours * 60 + minuteComponent;
+    }
+
+    const [hoursPart, minutesPart] = normalizedTime.split(':');
     if (hoursPart == null || minutesPart == null) {
         return null;
     }


### PR DESCRIPTION
### Motivation
- The return-date prompt was incorrectly suggesting the same-day return when end times were entered as 12-hour AM/PM strings (e.g. `03:00 PM`) because `parseTimeToMinutes` only handled 24-hour formats.  
- Ensure half-day or short-duration leave calculations treat a 3:00 PM end as day-close so the return date becomes the next valid workday when appropriate.

### Description
- Added trimming/normalization of `timeValue` in `parseTimeToMinutes` to guard against whitespace and empty strings.  
- Implemented a 12-hour AM/PM parser using a regex and strict validation for hours (1–12) and minutes (0–59), converting matched values to minutes-since-midnight.  
- Kept existing 24-hour parsing and validation intact by falling back to the previous `HH:MM` split when no AM/PM match is found.

### Testing
- Ran a Node sanity check with `parseTimeToMinutes` against `03:00 PM`, `15:00`, and `12:00 AM`, and observed expected minute outputs.  
- Attempted browser-level verification with a Playwright script to capture the return-date confirmation message, but the local app endpoint `http://127.0.0.1:8080` returned `ERR_EMPTY_RESPONSE` so no browser screenshot was produced.  
- No automated unit test suite was present in the repo for this function; only the Node sanity check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd7a97f6883259c11c2c7c6ede944)